### PR TITLE
Display session notes and enable exercise search

### DIFF
--- a/controllers/TreatmentController.php
+++ b/controllers/TreatmentController.php
@@ -79,13 +79,20 @@ class TreatmentController {
 
     public function getPreviousSessionExercises($patient_id) {
         $stmt = $this->pdo->prepare("
-            SELECT te.* , em.name , ts.session_date 
-            FROM treatment_exercises te
-            JOIN treatment_sessions ts ON ts.id = te.session_id
-            JOIN exercises_master em ON te.exercise_id = em.id
+            SELECT ts.id AS session_id,
+                   ts.session_date,
+                   ts.remarks,
+                   ts.progress_notes,
+                   te.exercise_id,
+                   te.reps,
+                   te.duration_minutes,
+                   te.notes,
+                   em.name
+            FROM treatment_sessions ts
+            LEFT JOIN treatment_exercises te ON ts.id = te.session_id
+            LEFT JOIN exercises_master em ON te.exercise_id = em.id
             WHERE ts.patient_id = ?
-            ORDER BY ts.session_date DESC, ts.id DESC
-            LIMIT 10
+            ORDER BY ts.session_date DESC, ts.id DESC, te.id
         ");
         $stmt->execute([$patient_id]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -11,8 +11,9 @@
   </div>
 </div>
 
-
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script src="/assets/js/script.js"></script>
 </body>
 </html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -7,6 +7,7 @@
     <meta charset="UTF-8">
     <title>Physio Clinic System</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     <link href="/assets/css/style.css" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Show doctor's remarks and progress notes for each previous session within the accordion.
- Add Select2-powered exercise selector for quick typing through long exercise lists.
- Include Select2 assets and initialize selectable fields dynamically.

## Testing
- `php -l controllers/TreatmentController.php`
- `php -l views/doctor/start_treatment.php`
- `php -l includes/header.php`
- `php -l includes/footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5732dd4588322b8f7d1731203b042