### PR TITLE
Add doctor and receptionist dashboards with statistics

### DIFF
--- a/layouts/doctor_sidebar.php
+++ b/layouts/doctor_sidebar.php
@@ -4,7 +4,7 @@
 <div class="sidebar bg-light p-3">
     <h5>Doctor Panel</h5>
     <ul class="list-group">
-        <li class="list-group-item"><a href="<?= BASE_URL ?>/views/dashboard/doctor_dashboard.php">Dashboard</a></li>
+        <li class="list-group-item"><a href="<?= BASE_URL ?>/views/doctor/dashboard/">Dashboard</a></li>
         <li class="list-group-item"><a href="<?= BASE_URL ?>/views/doctor/manage_patients.php">Manage Patients</a></li>
         <li class="list-group-item"><a href="<?= BASE_URL ?>/views/shared/logout.php">Logout</a></li>
     </ul>

--- a/layouts/receptionist_sidebar.php
+++ b/layouts/receptionist_sidebar.php
@@ -4,7 +4,7 @@
 <div class="sidebar bg-light p-3">
     <h5>Receptionist Panel</h5>
     <ul class="list-group">
-        <li class="list-group-item"><a href="<?= BASE_URL ?>/dashboard/receptionist_dashboard">Dashboard</a></li>
+        <li class="list-group-item"><a href="<?= BASE_URL ?>/views/receptionist/dashboard/">Dashboard</a></li>
         <li class="list-group-item"><a href="<?= BASE_URL ?>/views/receptionist/manage_patients.php">Manage Patients</a></li>
         <li class="list-group-item"><a href="<?= BASE_URL ?>/views/shared/logout.php">Logout</a></li>
     </ul>

--- a/views/dashboard/doctor_dashboard.php
+++ b/views/dashboard/doctor_dashboard.php
@@ -1,8 +1,14 @@
 <?php
 require_once '../../includes/session.php';
-require_once '../../includes/auth.php'; // Ensure correct relative path
+require_once '../../includes/auth.php';
+require_once '../../includes/db.php';
 requireLogin();
 requireRole('Doctor');
+
+// Fetch dashboard stats
+$totalPatients = $pdo->query("SELECT COUNT(*) FROM patients")->fetchColumn();
+$activePatients = $pdo->query("SELECT COUNT(DISTINCT patient_id) FROM treatment_episodes WHERE status = 'Active'")->fetchColumn();
+$totalExercises = $pdo->query("SELECT COUNT(*) FROM exercises_master")->fetchColumn();
 
 include '../../includes/header.php';
 ?>
@@ -11,6 +17,35 @@ include '../../includes/header.php';
   <div class="col-md-9">
     <h4>Doctor Dashboard</h4>
     <p>Welcome, Dr. <?= htmlspecialchars($_SESSION['name']) ?>!</p>
+    <div class="row g-4 mt-3">
+      <div class="col-md-4">
+        <div class="card text-bg-primary">
+          <div class="card-body">
+            <h5 class="card-title">Total Patients</h5>
+            <p class="display-6"><?= $totalPatients ?></p>
+            <a href="<?= BASE_URL ?>/views/doctor/manage_patients.php" class="btn btn-light btn-sm">View Patients</a>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card text-bg-success">
+          <div class="card-body">
+            <h5 class="card-title">Active Patients</h5>
+            <p class="display-6"><?= $activePatients ?></p>
+            <a href="<?= BASE_URL ?>/views/doctor/active_patients.php" class="btn btn-light btn-sm">View Active</a>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card text-bg-info">
+          <div class="card-body">
+            <h5 class="card-title">Total Exercises</h5>
+            <p class="display-6"><?= $totalExercises ?></p>
+            <a href="<?= BASE_URL ?>/views/doctor/exercises_list.php" class="btn btn-light btn-sm">View Exercises</a>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 <?php include '../../includes/footer.php'; ?>

--- a/views/dashboard/receptionist_dashboard.php
+++ b/views/dashboard/receptionist_dashboard.php
@@ -1,8 +1,12 @@
 <?php
 require_once '../../includes/session.php';
 require_once '../../includes/auth.php';
+require_once '../../includes/db.php';
 requireLogin();
 requireRole('Receptionist');
+
+$totalPatients = $pdo->query("SELECT COUNT(*) FROM patients")->fetchColumn();
+
 include '../../includes/header.php';
 ?>
 <div class="row">
@@ -10,6 +14,17 @@ include '../../includes/header.php';
   <div class="col-md-9">
     <h4>Receptionist Dashboard</h4>
     <p>Welcome, <?= htmlspecialchars($_SESSION['name']) ?>!</p>
+    <div class="row g-4 mt-3">
+      <div class="col-md-4">
+        <div class="card text-bg-primary">
+          <div class="card-body">
+            <h5 class="card-title">Total Patients</h5>
+            <p class="display-6"><?= $totalPatients ?></p>
+            <a href="<?= BASE_URL ?>/views/receptionist/manage_patients.php" class="btn btn-light btn-sm">Manage Patients</a>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 <?php include '../../includes/footer.php'; ?>

--- a/views/doctor/active_patients.php
+++ b/views/doctor/active_patients.php
@@ -1,0 +1,48 @@
+<?php
+require_once '../../includes/db.php';
+require_once '../../includes/auth.php';
+requireLogin();
+requireRole('Doctor');
+
+// Fetch active patients
+$sql = "SELECT DISTINCT p.* FROM patients p
+        JOIN treatment_episodes te ON te.patient_id = p.id
+        WHERE te.status = 'Active'
+        ORDER BY p.id DESC";
+$patients = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+
+include '../../includes/header.php';
+?>
+<div class="row">
+  <div class="col-md-3"><?php include '../../layouts/doctor_sidebar.php'; ?></div>
+  <div class="col-md-9">
+    <h4>Active Patients</h4>
+    <table class="table table-bordered table-hover">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Gender</th>
+          <th>DOB</th>
+          <th>Contact</th>
+          <th>Referral</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($patients as $p): ?>
+        <tr>
+          <td><?= htmlspecialchars($p['first_name'] . ' ' . $p['last_name']) ?></td>
+          <td><?= htmlspecialchars($p['gender']) ?></td>
+          <td><?= htmlspecialchars($p['date_of_birth']) ?></td>
+          <td><?= htmlspecialchars($p['contact_number']) ?></td>
+          <td><?= htmlspecialchars($p['referral_source']) ?></td>
+          <td>
+            <a href="select_or_create_episode.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-info">View</a>
+          </td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+</div>
+<?php include '../../includes/footer.php'; ?>

--- a/views/doctor/dashboard/index.php
+++ b/views/doctor/dashboard/index.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/../dashboard/doctor_dashboard.php';

--- a/views/doctor/exercises_list.php
+++ b/views/doctor/exercises_list.php
@@ -1,0 +1,35 @@
+<?php
+require_once '../../includes/db.php';
+require_once '../../includes/auth.php';
+requireLogin();
+requireRole('Doctor');
+
+$exercises = $pdo->query("SELECT name, default_reps, default_duration_minutes FROM exercises_master ORDER BY name" )->fetchAll(PDO::FETCH_ASSOC);
+
+include '../../includes/header.php';
+?>
+<div class="row">
+  <div class="col-md-3"><?php include '../../layouts/doctor_sidebar.php'; ?></div>
+  <div class="col-md-9">
+    <h4>Exercises</h4>
+    <table class="table table-bordered table-hover">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Default Reps</th>
+          <th>Default Duration (min)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($exercises as $ex): ?>
+        <tr>
+          <td><?= htmlspecialchars($ex['name']) ?></td>
+          <td><?= htmlspecialchars($ex['default_reps']) ?></td>
+          <td><?= htmlspecialchars($ex['default_duration_minutes']) ?></td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+</div>
+<?php include '../../includes/footer.php'; ?>

--- a/views/receptionist/dashboard/index.php
+++ b/views/receptionist/dashboard/index.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/../dashboard/receptionist_dashboard.php';


### PR DESCRIPTION
## Summary
- Display total, active, and exercise counts in new doctor dashboard cards with quick links
- Add receptionist dashboard card showing total patients with quick access
- Provide doctor pages for active patients and exercise list
- Fix and update sidebar links to new dashboard locations

## Testing
- `php -l layouts/doctor_sidebar.php`
- `php -l layouts/receptionist_sidebar.php`
- `php -l views/dashboard/doctor_dashboard.php`
- `php -l views/dashboard/receptionist_dashboard.php`
- `php -l views/doctor/active_patients.php`
- `php -l views/doctor/exercises_list.php`
- `php -l views/doctor/dashboard/index.php`
- `php -l views/receptionist/dashboard/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5bbfe64f08322a402fc1823083762