### PR TITLE
Filter session history by episode

### DIFF
--- a/controllers/TreatmentController.php
+++ b/controllers/TreatmentController.php
@@ -13,12 +13,13 @@ class TreatmentController {
 
             // Insert treatment session
             $stmt = $this->pdo->prepare("
-                INSERT INTO treatment_sessions 
-                (patient_id, session_date, doctor_id, remarks, progress_notes) 
-                VALUES (:patient_id, :session_date, :doctor_id, :remarks, :progress_notes)
+                INSERT INTO treatment_sessions
+                (patient_id, episode_id, session_date, doctor_id, remarks, progress_notes)
+                VALUES (:patient_id, :episode_id, :session_date, :doctor_id, :remarks, :progress_notes)
             ");
             $stmt->execute([
                 'patient_id' => $data['patient_id'],
+                'episode_id' => $data['episode_id'],
                 'session_date' => $data['session_date'],
                 'doctor_id' => $data['doctor_id'],
                 'remarks' => $data['remarks'] ?? null,
@@ -77,7 +78,7 @@ class TreatmentController {
         }
     }
 
-    public function getPreviousSessionExercises($patient_id) {
+    public function getPreviousSessionExercises($patient_id, $episode_id) {
         $stmt = $this->pdo->prepare("
             SELECT ts.id AS session_id,
                    ts.session_date,
@@ -91,10 +92,10 @@ class TreatmentController {
             FROM treatment_sessions ts
             LEFT JOIN treatment_exercises te ON ts.id = te.session_id
             LEFT JOIN exercises_master em ON te.exercise_id = em.id
-            WHERE ts.patient_id = ?
+            WHERE ts.patient_id = ? AND ts.episode_id = ?
             ORDER BY ts.session_date DESC, ts.id DESC, te.id
         ");
-        $stmt->execute([$patient_id]);
+        $stmt->execute([$patient_id, $episode_id]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 }

--- a/views/doctor/save_treatment.php
+++ b/views/doctor/save_treatment.php
@@ -7,9 +7,13 @@ requireRole('Doctor');
 $treatmentController = new TreatmentController($pdo);
 
 // Validate essential fields
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['patient_id'], $_POST['session_date'], $_POST['doctor_id'])) {
+if (
+    $_SERVER['REQUEST_METHOD'] === 'POST' &&
+    isset($_POST['patient_id'], $_POST['episode_id'], $_POST['session_date'], $_POST['doctor_id'])
+) {
     $data = [
         'patient_id' => $_POST['patient_id'],
+        'episode_id' => $_POST['episode_id'],
         'session_date' => $_POST['session_date'],
         'doctor_id' => $_POST['doctor_id'],
         'remarks' => $_POST['remarks'] ?? '',

--- a/views/doctor/start_treatment.php
+++ b/views/doctor/start_treatment.php
@@ -15,7 +15,9 @@ $patientData = $patientController->getPatientById($patient_id);
 $patient_name = $patientData['first_name']." ".$patientData['last_name'] ;
 
 $exercise_master = $pdo->query("SELECT id, name  FROM exercises_master WHERE is_active = 1 ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
-$previousExercises = $patient_id ? $treatmentController->getPreviousSessionExercises($patient_id) : [];
+$previousExercises = ($patient_id && $episode_id)
+    ? $treatmentController->getPreviousSessionExercises($patient_id, $episode_id)
+    : [];
 
 $msg = null;
 
@@ -30,6 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     
     $data = [
         'patient_id' => $_POST['patient_id'],
+        'episode_id' => $_POST['episode_id'],
         'session_date' => $_POST['session_date'],
         'doctor_id' => $_SESSION['user_id'],
         'remarks' => $_POST['remarks'] ?? '',


### PR DESCRIPTION
## Summary
- associate treatment sessions with their episode
- fetch previous sessions per episode when starting treatment
- ensure all session saves include episode reference

## Testing
- `php -l controllers/TreatmentController.php`
- `php -l views/doctor/start_treatment.php`
- `php -l views/doctor/save_treatment.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6b32770f08322b9a8d299c20c5ebe