### PR TITLE
Add patient history step and report uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+uploads/

--- a/config/file_master.sql
+++ b/config/file_master.sql
@@ -1,0 +1,8 @@
+CREATE TABLE file_master (
+  file_id INT AUTO_INCREMENT PRIMARY KEY,
+  patient_id INT NOT NULL,
+  file_name VARCHAR(255) NOT NULL,
+  upload_date DATETIME NOT NULL,
+  FOREIGN KEY (patient_id) REFERENCES patients(id) ON DELETE CASCADE
+);
+

--- a/config/update_patients_table.sql
+++ b/config/update_patients_table.sql
@@ -1,0 +1,10 @@
+ALTER TABLE patients
+  ADD COLUMN allergy_medicines_in_use TEXT,
+  ADD COLUMN family_history TEXT,
+  ADD COLUMN history TEXT,
+  ADD COLUMN chief_complaints TEXT,
+  ADD COLUMN assessment TEXT,
+  ADD COLUMN investigation TEXT,
+  ADD COLUMN diagnosis TEXT,
+  ADD COLUMN goal TEXT;
+

--- a/views/admin/patient_form.php
+++ b/views/admin/patient_form.php
@@ -42,7 +42,7 @@ include '../../includes/header.php';
       <div class="alert alert-info"><?= htmlspecialchars($msg) ?></div>
     <?php endif; ?>
 
-    <form method="POST" id="patientForm">
+    <form method="POST" id="patientForm" enctype="multipart/form-data">
       <?php include '../../views/shared/patient_form_content.php'; ?>
     </form>
   </div>

--- a/views/doctor/patient_form.php
+++ b/views/doctor/patient_form.php
@@ -41,7 +41,7 @@ include '../../includes/header.php';
       <div class="alert alert-info"><?= htmlspecialchars($msg) ?></div>
     <?php endif; ?>
 
-    <form method="POST" id="patientForm">
+    <form method="POST" id="patientForm" enctype="multipart/form-data">
       <?php include '../../views/shared/patient_form_content.php'; ?>
     </form>
   </div>

--- a/views/shared/patient_form_content.php
+++ b/views/shared/patient_form_content.php
@@ -3,6 +3,8 @@
   <li class="nav-item"><a class="nav-link active" data-bs-toggle="tab" href="#step1">Step 1</a></li>
   <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#step2">Step 2</a></li>
   <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#step3">Step 3</a></li>
+  <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#step4">Step 4</a></li>
+  <li class="nav-item"><a class="nav-link" data-bs-toggle="tab" href="#step5">Step 5</a></li>
 </ul>
 
 <div class="tab-content border p-3 bg-light">
@@ -71,6 +73,43 @@
             </option>
           <?php endforeach; ?>
         </select>
+      </div>
+    </div>
+  </div>
+  <!-- Step 4 -->
+  <div class="tab-pane fade" id="step4">
+    <div class="row g-3">
+      <div class="col-md-6"><label>Allergy - medicines in use</label>
+        <textarea name="allergy_medicines_in_use" class="form-control"><?= htmlspecialchars($patient['allergy_medicines_in_use'] ?? '') ?></textarea>
+      </div>
+      <div class="col-md-6"><label>Family history</label>
+        <textarea name="family_history" class="form-control"><?= htmlspecialchars($patient['family_history'] ?? '') ?></textarea>
+      </div>
+      <div class="col-md-6"><label>History</label>
+        <textarea name="history" class="form-control"><?= htmlspecialchars($patient['history'] ?? '') ?></textarea>
+      </div>
+      <div class="col-md-6"><label>Chief Complaints</label>
+        <textarea name="chief_complaints" class="form-control"><?= htmlspecialchars($patient['chief_complaints'] ?? '') ?></textarea>
+      </div>
+      <div class="col-md-6"><label>Assessment</label>
+        <textarea name="assessment" class="form-control"><?= htmlspecialchars($patient['assessment'] ?? '') ?></textarea>
+      </div>
+      <div class="col-md-6"><label>Investigation</label>
+        <textarea name="investigation" class="form-control"><?= htmlspecialchars($patient['investigation'] ?? '') ?></textarea>
+      </div>
+      <div class="col-md-6"><label>Diagnosis</label>
+        <textarea name="diagnosis" class="form-control"><?= htmlspecialchars($patient['diagnosis'] ?? '') ?></textarea>
+      </div>
+      <div class="col-md-6"><label>Goal</label>
+        <textarea name="goal" class="form-control"><?= htmlspecialchars($patient['goal'] ?? '') ?></textarea>
+      </div>
+    </div>
+  </div>
+  <!-- Step 5 -->
+  <div class="tab-pane fade" id="step5">
+    <div class="row g-3">
+      <div class="col-md-12"><label>Reports Upload (max 5 files)</label>
+        <input type="file" name="reports[]" class="form-control" multiple>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- extend shared patient form with new step capturing history, assessments and goals
- allow report uploads with new final step and multipart forms for admin, doctor and receptionist
- save additional patient fields and uploaded files via `PatientController`

## Testing
- `php -l controllers/PatientController.php`
- `php -l views/shared/patient_form_content.php`
- `php -l views/admin/patient_form.php`
- `php -l views/doctor/patient_form.php`
- `php -l views/receptionist/patient_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68c67ce791d883228b5c0c5b719f5049