### PR TITLE
Fix patient document download path

### DIFF
--- a/views/shared/download_file.php
+++ b/views/shared/download_file.php
@@ -1,0 +1,31 @@
+<?php
+
+$patientId = isset($_GET['patient_id']) ? preg_replace('/[^0-9]/', '', $_GET['patient_id']) : '';
+$fileName  = isset($_GET['file']) ? basename($_GET['file']) : '';
+
+if ($patientId === '' || $fileName === '') {
+    http_response_code(404);
+    exit('File not found.');
+}
+
+$filePath = dirname(__DIR__, 2) . '/uploads/patient_docs/' . $patientId . '/' . $fileName;
+
+if (!is_file($filePath) || !is_readable($filePath)) {
+    http_response_code(404);
+    exit('File not found.');
+}
+
+$mimeType = mime_content_type($filePath);
+if ($mimeType === false) {
+    $mimeType = 'application/octet-stream';
+}
+
+header('Content-Description: File Transfer');
+header('Content-Type: ' . $mimeType);
+header('Content-Disposition: attachment; filename="' . $fileName . '"');
+header('Content-Length: ' . filesize($filePath));
+header('Cache-Control: no-cache, must-revalidate');
+header('Pragma: public');
+readfile($filePath);
+exit;
+?>

--- a/views/shared/patient_form_content.php
+++ b/views/shared/patient_form_content.php
@@ -120,7 +120,9 @@
             <tr>
               <td><?= htmlspecialchars($file['file_name']) ?></td>
               <td><?= date('d M Y', strtotime($file['upload_date'])) ?></td>
-              <td><a href="/uploads/patient_docs/<?= htmlspecialchars($patient['id']) ?>/<?= htmlspecialchars($file['file_name']) ?>" class="btn btn-sm btn-primary" download>Download</a></td>
+              <td>
+                <a href="<?= BASE_URL ?>/views/shared/download_file.php?patient_id=<?= urlencode($patient['id']) ?>&file=<?= urlencode($file['file_name']) ?>" class="btn btn-sm btn-primary">Download</a>
+              </td>
             </tr>
             <?php endforeach; ?>
           </tbody>


### PR DESCRIPTION
## Summary
- Ensure patient document links use application base URL
- Add secure download handler supporting attachments for any file type

## Testing
- `php -l views/shared/patient_form_content.php`
- `php -l views/shared/download_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6881978cc8322aaeb88a4476e3bd0