### PR TITLE
Add patient file viewer and file access links

### DIFF
--- a/views/admin/manage_patients.php
+++ b/views/admin/manage_patients.php
@@ -57,6 +57,7 @@ include '../../includes/header.php';
           <td><?= htmlspecialchars($p['referral_source']) ?></td>
           <td>
             <a href="patient_form.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-info">Edit</a>
+            <a href="../shared/manage_patients_files.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">View Files</a>
           </td>
         </tr>
         <?php endforeach; ?>

--- a/views/doctor/manage_patients.php
+++ b/views/doctor/manage_patients.php
@@ -58,6 +58,7 @@ include '../../includes/header.php';
           <td>
             <a href="select_or_create_episode.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-info">Start Treatment</a>
             <a href="patient_form.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-info">Edit</a>
+            <a href="../shared/manage_patients_files.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">View Files</a>
           </td>
         </tr>
         <?php endforeach; ?>

--- a/views/receptionist/manage_patients.php
+++ b/views/receptionist/manage_patients.php
@@ -33,6 +33,7 @@ $patients = $stmt->fetchAll();
             <td><?= htmlspecialchars($p['contact_number']) ?></td>
             <td>
               <a href="patient_form.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-primary">Edit</a>
+              <a href="../shared/manage_patients_files.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">View Files</a>
             </td>
           </tr>
         <?php endforeach; ?>

--- a/views/shared/manage_patients_files.php
+++ b/views/shared/manage_patients_files.php
@@ -1,0 +1,80 @@
+<?php
+require_once '../../includes/db.php';
+require_once '../../includes/auth.php';
+requireLogin();
+if (!in_array($_SESSION['role'] ?? '', ['Admin','Doctor','Receptionist'])) {
+    header('Location: ../login.php');
+    exit;
+}
+
+require_once '../../controllers/PatientController.php';
+$controller = new PatientController($pdo);
+
+$patientId = isset($_GET['patient_id']) ? (int)$_GET['patient_id'] : 0;
+if ($patientId <= 0) {
+    exit('Invalid patient ID.');
+}
+
+$patient = $controller->getPatientById($patientId);
+if (!$patient) {
+    exit('Patient not found.');
+}
+$files = $controller->getPatientFiles($patientId);
+
+include '../../includes/header.php';
+?>
+
+<div class="row">
+  <div class="col-md-3">
+    <?php
+      switch ($_SESSION['role']) {
+        case 'Doctor':
+          include '../../layouts/doctor_sidebar.php';
+          break;
+        case 'Receptionist':
+          include '../../layouts/receptionist_sidebar.php';
+          break;
+        default:
+          include '../../layouts/admin_sidebar.php';
+      }
+    ?>
+  </div>
+  <div class="col-md-9">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h4>Files for <?= htmlspecialchars($patient['first_name'] . ' ' . $patient['last_name']) ?></h4>
+      <a href="javascript:history.back()" class="btn btn-secondary">Back</a>
+    </div>
+    <p>
+      <strong>Gender:</strong> <?= htmlspecialchars($patient['gender']) ?> |
+      <strong>DOB:</strong> <?= htmlspecialchars($patient['date_of_birth']) ?> |
+      <strong>Contact:</strong> <?= htmlspecialchars($patient['contact_number']) ?>
+    </p>
+
+    <?php if (!empty($files)): ?>
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>File Name</th>
+          <th>Uploaded On</th>
+          <th>Download</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($files as $file): ?>
+        <tr>
+          <td><?= htmlspecialchars($file['file_name']) ?></td>
+          <td><?= date('d M Y', strtotime($file['upload_date'])) ?></td>
+          <td>
+            <a href="<?= BASE_URL ?>/views/shared/download_file.php?patient_id=<?= $patientId ?>&file=<?= urlencode($file['file_name']) ?>" class="btn btn-sm btn-primary">Download</a>
+          </td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+    <?php else: ?>
+      <p>No files uploaded for this patient.</p>
+    <?php endif; ?>
+  </div>
+</div>
+
+<?php include '../../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add View Files button on admin, doctor, and receptionist patient lists
- create shared page to display patient details and downloadable files

## Testing
- `php -l views/doctor/manage_patients.php`
- `php -l views/receptionist/manage_patients.php`
- `php -l views/admin/manage_patients.php`
- `php -l views/shared/manage_patients_files.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6994d9d9c83228a79786f5db1aa25