### PR TITLE
Add payment management with CRUD and schema

### DIFF
--- a/config/payments.sql
+++ b/config/payments.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS payments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    patient_id INT NOT NULL,
+    payment_date DATE NOT NULL,
+    amount DECIMAL(10,2) NOT NULL,
+    episodes_covered INT DEFAULT 0,
+    treatment_covered VARCHAR(255) DEFAULT NULL,
+    status ENUM('received','pending') NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (patient_id) REFERENCES patients(id) ON DELETE CASCADE
+);

--- a/controllers/PaymentController.php
+++ b/controllers/PaymentController.php
@@ -1,0 +1,46 @@
+<?php
+class PaymentController {
+    private $pdo;
+
+    public function __construct($pdo) {
+        $this->pdo = $pdo;
+    }
+
+    public function getPaymentsByPatient($patientId, $status) {
+        $stmt = $this->pdo->prepare("SELECT * FROM payments WHERE patient_id = ? AND status = ? ORDER BY payment_date DESC, id DESC");
+        $stmt->execute([$patientId, $status]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getPaymentById($id) {
+        $stmt = $this->pdo->prepare("SELECT * FROM payments WHERE id = ?");
+        $stmt->execute([$id]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function savePayment($data) {
+        if (!empty($data['id'])) {
+            $sql = "UPDATE payments SET payment_date = :payment_date, amount = :amount, episodes_covered = :episodes_covered, treatment_covered = :treatment_covered, status = :status, updated_at = NOW() WHERE id = :id";
+        } else {
+            $sql = "INSERT INTO payments (patient_id, payment_date, amount, episodes_covered, treatment_covered, status, created_at, updated_at) VALUES (:patient_id, :payment_date, :amount, :episodes_covered, :treatment_covered, :status, NOW(), NOW())";
+        }
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->bindValue(':payment_date', $data['payment_date']);
+        $stmt->bindValue(':amount', $data['amount']);
+        $stmt->bindValue(':episodes_covered', $data['episodes_covered']);
+        $stmt->bindValue(':treatment_covered', $data['treatment_covered']);
+        $stmt->bindValue(':status', $data['status']);
+        if (!empty($data['id'])) {
+            $stmt->bindValue(':id', $data['id'], PDO::PARAM_INT);
+        } else {
+            $stmt->bindValue(':patient_id', $data['patient_id'], PDO::PARAM_INT);
+        }
+        $stmt->execute();
+    }
+
+    public function deletePayment($id) {
+        $stmt = $this->pdo->prepare("DELETE FROM payments WHERE id = ?");
+        $stmt->execute([$id]);
+    }
+}
+?>

--- a/views/admin/manage_patients.php
+++ b/views/admin/manage_patients.php
@@ -57,6 +57,7 @@ include '../../includes/header.php';
           <td><?= htmlspecialchars($p['referral_source']) ?></td>
           <td>
             <a href="patient_form.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-info">Edit</a>
+            <a href="../shared/manage_payments.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-secondary">Payments</a>
             <a href="../shared/manage_patients_files.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">View Files</a>
           </td>
         </tr>

--- a/views/doctor/manage_patients.php
+++ b/views/doctor/manage_patients.php
@@ -58,6 +58,7 @@ include '../../includes/header.php';
           <td>
             <a href="select_or_create_episode.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-info">Start Treatment</a>
             <a href="patient_form.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-info">Edit</a>
+            <a href="../shared/manage_payments.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-secondary">Payments</a>
             <a href="../shared/manage_patients_files.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">View Files</a>
           </td>
         </tr>

--- a/views/receptionist/manage_patients.php
+++ b/views/receptionist/manage_patients.php
@@ -33,6 +33,7 @@ $patients = $stmt->fetchAll();
             <td><?= htmlspecialchars($p['contact_number']) ?></td>
             <td>
               <a href="patient_form.php?id=<?= $p['id'] ?>" class="btn btn-sm btn-primary">Edit</a>
+              <a href="../shared/manage_payments.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-secondary">Payments</a>
               <a href="../shared/manage_patients_files.php?patient_id=<?= $p['id'] ?>" class="btn btn-sm btn-warning">View Files</a>
             </td>
           </tr>

--- a/views/shared/manage_payments.php
+++ b/views/shared/manage_payments.php
@@ -1,0 +1,186 @@
+<?php
+require_once '../../includes/db.php';
+require_once '../../includes/auth.php';
+requireLogin();
+if (!in_array($_SESSION['role'] ?? '', ['Admin','Doctor','Receptionist'])) {
+    header('Location: ../login.php');
+    exit;
+}
+
+require_once '../../controllers/PatientController.php';
+require_once '../../controllers/PaymentController.php';
+$patientController = new PatientController($pdo);
+$paymentController = new PaymentController($pdo);
+
+$patientId = isset($_GET['patient_id']) ? (int)$_GET['patient_id'] : 0;
+if ($patientId <= 0) {
+    exit('Invalid patient ID.');
+}
+
+$patient = $patientController->getPatientById($patientId);
+if (!$patient) {
+    exit('Patient not found.');
+}
+
+// Handle delete
+if (isset($_GET['delete'])) {
+    $paymentController->deletePayment((int)$_GET['delete']);
+    header('Location: manage_payments.php?patient_id=' . $patientId);
+    exit;
+}
+
+// Handle form submission
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $data = [
+        'id' => $_POST['id'] ?? null,
+        'patient_id' => $patientId,
+        'payment_date' => $_POST['payment_date'] ?? date('Y-m-d'),
+        'amount' => $_POST['amount'] ?? 0,
+        'episodes_covered' => $_POST['episodes_covered'] ?? 0,
+        'treatment_covered' => $_POST['treatment_covered'] ?? '',
+        'status' => $_POST['status'] ?? 'received'
+    ];
+    $paymentController->savePayment($data);
+    header('Location: manage_payments.php?patient_id=' . $patientId);
+    exit;
+}
+
+$editPayment = null;
+if (isset($_GET['edit'])) {
+    $editPayment = $paymentController->getPaymentById((int)$_GET['edit']);
+}
+
+$receivedPayments = $paymentController->getPaymentsByPatient($patientId, 'received');
+$pendingPayments  = $paymentController->getPaymentsByPatient($patientId, 'pending');
+
+include '../../includes/header.php';
+?>
+
+<div class="row">
+  <div class="col-md-3">
+    <?php
+      switch ($_SESSION['role']) {
+        case 'Doctor':
+          include '../../layouts/doctor_sidebar.php';
+          break;
+        case 'Receptionist':
+          include '../../layouts/receptionist_sidebar.php';
+          break;
+        default:
+          include '../../layouts/admin_sidebar.php';
+      }
+    ?>
+  </div>
+  <div class="col-md-9">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h4>Payments for <?= htmlspecialchars($patient['first_name'] . ' ' . $patient['last_name']) ?></h4>
+      <a href="javascript:history.back()" class="btn btn-secondary">Back</a>
+    </div>
+
+    <form method="post" class="mb-4">
+      <input type="hidden" name="id" value="<?= $editPayment['id'] ?? '' ?>">
+      <div class="row g-2">
+        <div class="col-md-3">
+          <label class="form-label">Date</label>
+          <input type="date" name="payment_date" class="form-control" value="<?= $editPayment['payment_date'] ?? '' ?>">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Amount</label>
+          <input type="number" step="0.01" name="amount" class="form-control" value="<?= $editPayment['amount'] ?? '' ?>">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Episodes</label>
+          <input type="number" name="episodes_covered" class="form-control" value="<?= $editPayment['episodes_covered'] ?? '' ?>">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Treatment Covered</label>
+          <input type="text" name="treatment_covered" class="form-control" value="<?= htmlspecialchars($editPayment['treatment_covered'] ?? '') ?>">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Status</label>
+          <select name="status" class="form-select">
+            <option value="received" <?= (isset($editPayment['status']) && $editPayment['status'] === 'received') ? 'selected' : '' ?>>Received</option>
+            <option value="pending" <?= (isset($editPayment['status']) && $editPayment['status'] === 'pending') ? 'selected' : '' ?>>Pending</option>
+          </select>
+        </div>
+      </div>
+      <div class="mt-3">
+        <button class="btn btn-primary">Save Payment</button>
+        <?php if ($editPayment): ?>
+          <a href="manage_payments.php?patient_id=<?= $patientId ?>" class="btn btn-secondary">Cancel</a>
+        <?php endif; ?>
+      </div>
+    </form>
+
+    <ul class="nav nav-tabs" id="paymentTabs" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="received-tab" data-bs-toggle="tab" data-bs-target="#received" type="button" role="tab">Received</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="pending-tab" data-bs-toggle="tab" data-bs-target="#pending" type="button" role="tab">Pending</button>
+      </li>
+    </ul>
+    <div class="tab-content mt-3">
+      <div class="tab-pane fade show active" id="received" role="tabpanel">
+        <?php if (!empty($receivedPayments)): ?>
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Amount</th>
+              <th>Episode + Treatment</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($receivedPayments as $pay): ?>
+            <tr>
+              <td><?= htmlspecialchars($pay['payment_date']) ?></td>
+              <td><?= htmlspecialchars($pay['amount']) ?></td>
+              <td><?= htmlspecialchars($pay['episodes_covered'] . ' / ' . $pay['treatment_covered']) ?></td>
+              <td>
+                <a href="?patient_id=<?= $patientId ?>&edit=<?= $pay['id'] ?>" class="btn btn-sm btn-primary">Edit</a>
+                <a href="?patient_id=<?= $patientId ?>&delete=<?= $pay['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete payment?');">Delete</a>
+              </td>
+            </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+        <?php else: ?>
+          <p>No received payments recorded.</p>
+        <?php endif; ?>
+      </div>
+      <div class="tab-pane fade" id="pending" role="tabpanel">
+        <?php if (!empty($pendingPayments)): ?>
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Amount</th>
+              <th>Episode + Treatment</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($pendingPayments as $pay): ?>
+            <tr>
+              <td><?= htmlspecialchars($pay['payment_date']) ?></td>
+              <td><?= htmlspecialchars($pay['amount']) ?></td>
+              <td><?= htmlspecialchars($pay['episodes_covered'] . ' / ' . $pay['treatment_covered']) ?></td>
+              <td>
+                <a href="?patient_id=<?= $patientId ?>&edit=<?= $pay['id'] ?>" class="btn btn-sm btn-primary">Edit</a>
+                <a href="?patient_id=<?= $patientId ?>&delete=<?= $pay['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete payment?');">Delete</a>
+              </td>
+            </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+        <?php else: ?>
+          <p>No pending payments.</p>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
+</div>
+
+<?php include '../../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add Payments button on patient listings for Admin, Doctor, and Receptionist
- implement shared payment management view with Received/Pending tabs
- introduce PaymentController and SQL schema for payments table

## Testing
- `php -l controllers/PaymentController.php`
- `php -l views/shared/manage_payments.php`
- `php -l views/doctor/manage_patients.php`
- `php -l views/receptionist/manage_patients.php`
- `php -l views/admin/manage_patients.php`


------
https://chatgpt.com/codex/tasks/task_e_68c69ea205188322959b35b970508adb