### PR TITLE
Improve payment handling and credit tracking

### DIFF
--- a/controllers/PaymentController.php
+++ b/controllers/PaymentController.php
@@ -12,6 +12,27 @@ class PaymentController {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public function getAllPaymentsByPatient($patientId) {
+        $stmt = $this->pdo->prepare("SELECT * FROM payments WHERE patient_id = ? ORDER BY payment_date DESC, id DESC");
+        $stmt->execute([$patientId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getPatientTotals($patientId) {
+        $stmt = $this->pdo->prepare("SELECT status, SUM(amount) AS total FROM payments WHERE patient_id = ? GROUP BY status");
+        $stmt->execute([$patientId]);
+        $totals = [
+            'pending' => 0.0,
+            'credit' => 0.0,
+        ];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            if (isset($totals[$row['status']])) {
+                $totals[$row['status']] = (float) $row['total'];
+            }
+        }
+        return $totals;
+    }
+
     public function getPaymentById($id) {
         $stmt = $this->pdo->prepare("SELECT * FROM payments WHERE id = ?");
         $stmt->execute([$id]);
@@ -19,56 +40,214 @@ class PaymentController {
     }
 
     public function savePayment($data) {
-        if (!empty($data['id'])) {
-            $sql = "UPDATE payments SET payment_date = :payment_date, amount = :amount, episodes_covered = :episodes_covered, treatment_covered = :treatment_covered, status = :status, updated_at = NOW() WHERE id = :id";
-        } else {
-            $sql = "INSERT INTO payments (patient_id, payment_date, amount, episodes_covered, treatment_covered, status, created_at, updated_at) VALUES (:patient_id, :payment_date, :amount, :episodes_covered, :treatment_covered, :status, NOW(), NOW())";
-        }
-        $stmt = $this->pdo->prepare($sql);
-        $stmt->bindValue(':payment_date', $data['payment_date']);
-        $stmt->bindValue(':amount', $data['amount']);
-        $stmt->bindValue(':episodes_covered', $data['episodes_covered']);
-        $stmt->bindValue(':treatment_covered', $data['treatment_covered']);
-        $stmt->bindValue(':status', $data['status']);
-        if (!empty($data['id'])) {
-            $stmt->bindValue(':id', $data['id'], PDO::PARAM_INT);
-        } else {
+        $this->pdo->beginTransaction();
+        try {
+            if (!empty($data['id'])) {
+                $sql = "UPDATE payments SET payment_date = :payment_date, amount = :amount, episodes_covered = :episodes_covered, treatment_covered = :treatment_covered, status = :status, updated_at = NOW() WHERE id = :id";
+                $stmt = $this->pdo->prepare($sql);
+                $stmt->bindValue(':payment_date', $data['payment_date']);
+                $stmt->bindValue(':amount', $data['amount']);
+                $this->bindNullable($stmt, ':episodes_covered', $data['episodes_covered'], PDO::PARAM_INT);
+                $this->bindNullable($stmt, ':treatment_covered', $data['treatment_covered'], PDO::PARAM_STR);
+                $stmt->bindValue(':status', $data['status']);
+                $stmt->bindValue(':id', $data['id'], PDO::PARAM_INT);
+                $stmt->execute();
+                $this->pdo->commit();
+                return;
+            }
+
+            $sql = "INSERT INTO payments (patient_id, payment_date, amount, episodes_covered, treatment_covered, status, created_at, updated_at) VALUES (:patient_id, :payment_date, :amount, :episodes_covered, :treatment_covered, 'received', NOW(), NOW())";
+            $stmt = $this->pdo->prepare($sql);
             $stmt->bindValue(':patient_id', $data['patient_id'], PDO::PARAM_INT);
+            $stmt->bindValue(':payment_date', $data['payment_date']);
+            $stmt->bindValue(':amount', $data['amount']);
+            $this->bindNullable($stmt, ':episodes_covered', $data['episodes_covered'], PDO::PARAM_INT);
+            $this->bindNullable($stmt, ':treatment_covered', $data['treatment_covered'], PDO::PARAM_STR);
+            $stmt->execute();
+
+            $amount = (float) $data['amount'];
+            $remaining = $this->applyAmountToPending($data['patient_id'], $amount);
+            if ($remaining > 0) {
+                $this->storeCredit($data['patient_id'], $remaining, $data['payment_date']);
+                $this->applyCreditsToPending($data['patient_id']);
+            }
+
+            $this->pdo->commit();
+        } catch (Exception $e) {
+            $this->pdo->rollBack();
+            throw $e;
         }
-        $stmt->execute();
     }
 
     /**
-     * Record payment information for a treatment session. If a payment entry
-     * already exists for the given patient/episode/session date, update the
-     * amount while retaining its status. Otherwise insert a new payment marked
-     * as pending.
+     * Record payment information for a treatment session and automatically
+     * apply available credit to mark the session as received when possible.
      */
     public function recordSessionPayment($patientId, $episodeId, $sessionDate, $amount) {
-        $stmt = $this->pdo->prepare(
-            "SELECT id, status FROM payments WHERE patient_id = ? AND episodes_covered = ? AND treatment_covered = ?"
-        );
-        $stmt->execute([$patientId, $episodeId, $sessionDate]);
-        $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+        $this->pdo->beginTransaction();
+        $committed = false;
+        try {
+            $stmt = $this->pdo->prepare(
+                "SELECT id FROM payments WHERE patient_id = ? AND episodes_covered = ? AND treatment_covered = ?"
+            );
+            $stmt->execute([$patientId, $episodeId, $sessionDate]);
+            $existing = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        if ($existing) {
-            $update = $this->pdo->prepare(
-                "UPDATE payments SET payment_date = ?, amount = ?, updated_at = NOW() WHERE id = ?"
-            );
-            $update->execute([$sessionDate, $amount, $existing['id']]);
-            return $existing['status'];
-        } else {
-            $insert = $this->pdo->prepare(
-                "INSERT INTO payments (patient_id, payment_date, amount, episodes_covered, treatment_covered, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'pending', NOW(), NOW())"
-            );
-            $insert->execute([$patientId, $sessionDate, $amount, $episodeId, $sessionDate]);
-            return 'pending';
+            if ($existing) {
+                $update = $this->pdo->prepare(
+                    "UPDATE payments SET payment_date = ?, amount = ?, status = 'pending', updated_at = NOW() WHERE id = ?"
+                );
+                $update->execute([$sessionDate, $amount, $existing['id']]);
+            } else {
+                $insert = $this->pdo->prepare(
+                    "INSERT INTO payments (patient_id, payment_date, amount, episodes_covered, treatment_covered, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'pending', NOW(), NOW())"
+                );
+                $insert->execute([$patientId, $sessionDate, $amount, $episodeId, $sessionDate]);
+            }
+
+            $this->applyCreditsToPending($patientId);
+            $this->pdo->commit();
+            $committed = true;
+        } catch (Exception $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+
+        if ($committed) {
+            $this->rebuildPatientLedger($patientId);
         }
     }
 
     public function deletePayment($id) {
-        $stmt = $this->pdo->prepare("DELETE FROM payments WHERE id = ?");
+        $stmt = $this->pdo->prepare("SELECT patient_id FROM payments WHERE id = ?");
         $stmt->execute([$id]);
+        $patientId = $stmt->fetchColumn();
+
+        if (!$patientId) {
+            return;
+        }
+
+        $delete = $this->pdo->prepare("DELETE FROM payments WHERE id = ?");
+        $delete->execute([$id]);
+
+        $this->rebuildPatientLedger($patientId);
+    }
+
+    private function bindNullable($stmt, $param, $value, $type) {
+        if ($value === '' || $value === null) {
+            $stmt->bindValue($param, null, PDO::PARAM_NULL);
+        } else {
+            $stmt->bindValue($param, $value, $type);
+        }
+    }
+
+    private function applyAmountToPending($patientId, $amount) {
+        $amount = (float) $amount;
+        if ($amount <= 0) {
+            return 0.0;
+        }
+
+        $pendingStmt = $this->pdo->prepare(
+            "SELECT id, amount FROM payments WHERE patient_id = ? AND status = 'pending' ORDER BY payment_date ASC, id ASC"
+        );
+        $pendingStmt->execute([$patientId]);
+        $pending = $pendingStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach ($pending as $row) {
+            if ($amount <= 0) {
+                break;
+            }
+            $due = (float) $row['amount'];
+            if ($due <= 0) {
+                continue;
+            }
+
+            if ($amount + 1e-6 >= $due) {
+                $update = $this->pdo->prepare("UPDATE payments SET status = 'received', updated_at = NOW() WHERE id = ?");
+                $update->execute([$row['id']]);
+                $amount -= $due;
+            }
+        }
+
+        return $amount;
+    }
+
+    private function storeCredit($patientId, $amount, $paymentDate) {
+        if ($amount <= 0) {
+            return;
+        }
+
+        $stmt = $this->pdo->prepare("SELECT id, amount FROM payments WHERE patient_id = ? AND status = 'credit' ORDER BY payment_date ASC, id ASC LIMIT 1");
+        $stmt->execute([$patientId]);
+        $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($existing) {
+            $newAmount = (float) $existing['amount'] + $amount;
+            $update = $this->pdo->prepare("UPDATE payments SET amount = ?, payment_date = ?, updated_at = NOW() WHERE id = ?");
+            $update->execute([$newAmount, $paymentDate, $existing['id']]);
+        } else {
+            $insert = $this->pdo->prepare("INSERT INTO payments (patient_id, payment_date, amount, episodes_covered, treatment_covered, status, created_at, updated_at) VALUES (?, ?, ?, NULL, NULL, 'credit', NOW(), NOW())");
+            $insert->execute([$patientId, $paymentDate, $amount]);
+        }
+    }
+
+    private function applyCreditsToPending($patientId) {
+        $creditStmt = $this->pdo->prepare("SELECT id, amount, payment_date FROM payments WHERE patient_id = ? AND status = 'credit' ORDER BY payment_date ASC, id ASC");
+        $creditStmt->execute([$patientId]);
+        $credits = $creditStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach ($credits as $credit) {
+            $available = (float) $credit['amount'];
+            if ($available <= 0) {
+                $delete = $this->pdo->prepare("DELETE FROM payments WHERE id = ?");
+                $delete->execute([$credit['id']]);
+                continue;
+            }
+
+            $remaining = $this->applyAmountToPending($patientId, $available);
+            if ($remaining <= 1e-6) {
+                $delete = $this->pdo->prepare("DELETE FROM payments WHERE id = ?");
+                $delete->execute([$credit['id']]);
+            } else {
+                $update = $this->pdo->prepare("UPDATE payments SET amount = ?, updated_at = NOW() WHERE id = ?");
+                $update->execute([$remaining, $credit['id']]);
+            }
+        }
+    }
+
+    private function rebuildPatientLedger($patientId) {
+        $this->pdo->beginTransaction();
+        try {
+            $this->pdo->prepare("DELETE FROM payments WHERE patient_id = ? AND status = 'credit'")->execute([$patientId]);
+
+            $reset = $this->pdo->prepare("UPDATE payments SET status = 'pending' WHERE patient_id = ? AND treatment_covered IS NOT NULL");
+            $reset->execute([$patientId]);
+
+            $paymentsStmt = $this->pdo->prepare("SELECT payment_date, amount FROM payments WHERE patient_id = ? AND treatment_covered IS NULL AND status != 'credit' ORDER BY payment_date ASC, id ASC");
+            $paymentsStmt->execute([$patientId]);
+            $payments = $paymentsStmt->fetchAll(PDO::FETCH_ASSOC);
+
+            $credit = 0.0;
+            foreach ($payments as $payment) {
+                $credit += $this->applyPaymentAndReturnRemaining($patientId, (float) $payment['amount']);
+            }
+
+            if ($credit > 0) {
+                $lastDate = !empty($payments) ? end($payments)['payment_date'] : date('Y-m-d');
+                $this->storeCredit($patientId, $credit, $lastDate);
+                $this->applyCreditsToPending($patientId);
+            }
+
+            $this->pdo->commit();
+        } catch (Exception $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    private function applyPaymentAndReturnRemaining($patientId, $amount) {
+        $remaining = $this->applyAmountToPending($patientId, $amount);
+        return $remaining;
     }
 }
 ?>

--- a/views/shared/manage_payments.php
+++ b/views/shared/manage_payments.php
@@ -22,14 +22,9 @@ if (!$patient) {
     exit('Patient not found.');
 }
 
-// Fetch episodes and treatment sessions for dropdowns
-$episodesStmt = $pdo->prepare("SELECT id, start_date FROM treatment_episodes WHERE patient_id = ? ORDER BY start_date DESC");
-$episodesStmt->execute([$patientId]);
-$episodes = $episodesStmt->fetchAll(PDO::FETCH_ASSOC);
-
-$sessionsStmt = $pdo->prepare("SELECT episode_id, session_date FROM treatment_sessions WHERE patient_id = ? ORDER BY session_date DESC");
-$sessionsStmt->execute([$patientId]);
-$sessions = $sessionsStmt->fetchAll(PDO::FETCH_ASSOC);
+$msg = null;
+$paymentDateValue = date('Y-m-d');
+$amountValue = '';
 
 // Handle delete
 if (isset($_GET['delete'])) {
@@ -40,27 +35,28 @@ if (isset($_GET['delete'])) {
 
 // Handle form submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $data = [
-        'id' => $_POST['id'] ?? null,
-        'patient_id' => $patientId,
-        'payment_date' => $_POST['payment_date'] ?? date('Y-m-d'),
-        'amount' => $_POST['amount'] ?? 0,
-        'episodes_covered' => $_POST['episodes_covered'] ?? 0,
-        'treatment_covered' => $_POST['treatment_covered'] ?? '',
-        'status' => $_POST['status'] ?? 'received'
-    ];
-    $paymentController->savePayment($data);
-    header('Location: manage_payments.php?patient_id=' . $patientId);
-    exit;
+    $paymentDateValue = $_POST['payment_date'] ?? $paymentDateValue;
+    $amountValue = $_POST['amount'] ?? $amountValue;
+    $amount = isset($_POST['amount']) ? (float) $_POST['amount'] : 0;
+
+    if ($amount <= 0) {
+        $msg = 'Please enter a valid payment amount.';
+    } else {
+        $data = [
+            'patient_id' => $patientId,
+            'payment_date' => $paymentDateValue ?: date('Y-m-d'),
+            'amount' => $amount,
+            'episodes_covered' => null,
+            'treatment_covered' => null,
+        ];
+        $paymentController->savePayment($data);
+        header('Location: manage_payments.php?patient_id=' . $patientId);
+        exit;
+    }
 }
 
-$editPayment = null;
-if (isset($_GET['edit'])) {
-    $editPayment = $paymentController->getPaymentById((int)$_GET['edit']);
-}
-
-$receivedPayments = $paymentController->getPaymentsByPatient($patientId, 'received');
-$pendingPayments  = $paymentController->getPaymentsByPatient($patientId, 'pending');
+$paymentTotals = $paymentController->getPatientTotals($patientId);
+$allPayments = $paymentController->getAllPaymentsByPatient($patientId);
 
 include '../../includes/header.php';
 ?>
@@ -86,140 +82,95 @@ include '../../includes/header.php';
       <a href="javascript:history.back()" class="btn btn-secondary">Back</a>
     </div>
 
-    <form method="post" class="mb-4">
-      <input type="hidden" name="id" value="<?= $editPayment['id'] ?? '' ?>">
-      <div class="row g-2">
-        <div class="col-md-2">
-          <label class="form-label">Date</label>
-          <input type="date" name="payment_date" class="form-control" value="<?= $editPayment['payment_date'] ?? '' ?>">
-        </div>
-        <div class="col-md-2">
-          <label class="form-label">Amount</label>
-          <input type="number" step="0.01" name="amount" class="form-control" value="<?= $editPayment['amount'] ?? '' ?>">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Episode</label>
-          <select name="episodes_covered" id="episodeSelect" class="form-select">
-            <option value="">Select Episode</option>
-            <?php foreach ($episodes as $ep): ?>
-              <option value="<?= $ep['id'] ?>" <?= (isset($editPayment['episodes_covered']) && $editPayment['episodes_covered'] == $ep['id']) ? 'selected' : '' ?>>
-                Episode <?= $ep['id'] ?> (<?= htmlspecialchars($ep['start_date']) ?>)
-              </option>
-            <?php endforeach; ?>
-          </select>
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Treatment Covered</label>
-          <select name="treatment_covered" id="sessionSelect" class="form-select">
-            <option value="">Select Session</option>
-            <?php foreach ($sessions as $s): ?>
-              <option value="<?= htmlspecialchars($s['session_date']) ?>" data-episode="<?= $s['episode_id'] ?>" <?= (isset($editPayment['treatment_covered']) && $editPayment['treatment_covered'] == $s['session_date']) ? 'selected' : '' ?>>
-                <?= htmlspecialchars($s['session_date']) ?>
-              </option>
-            <?php endforeach; ?>
-          </select>
-        </div>
-        <div class="col-md-2">
-          <label class="form-label">Status</label>
-          <select name="status" class="form-select">
-            <option value="received" <?= (isset($editPayment['status']) && $editPayment['status'] === 'received') ? 'selected' : '' ?>>Received</option>
-            <option value="pending" <?= (isset($editPayment['status']) && $editPayment['status'] === 'pending') ? 'selected' : '' ?>>Pending</option>
-          </select>
+    <?php if ($msg): ?>
+      <div class="alert alert-warning"><?= htmlspecialchars($msg) ?></div>
+    <?php endif; ?>
+
+    <div class="row g-3 mb-4">
+      <div class="col-sm-6 col-lg-4">
+        <div class="card border-warning h-100">
+          <div class="card-body">
+            <div class="text-muted fw-semibold">Total Pending</div>
+            <div class="fs-5">R <?= number_format($paymentTotals['pending'] ?? 0, 2) ?></div>
+          </div>
         </div>
       </div>
-      <div class="mt-3">
-        <button class="btn btn-primary">Save Payment</button>
-        <?php if ($editPayment): ?>
-          <a href="manage_payments.php?patient_id=<?= $patientId ?>" class="btn btn-secondary">Cancel</a>
-        <?php endif; ?>
+      <div class="col-sm-6 col-lg-4">
+        <div class="card border-success h-100">
+          <div class="card-body">
+            <div class="text-muted fw-semibold">Total Credit</div>
+            <div class="fs-5">R <?= number_format($paymentTotals['credit'] ?? 0, 2) ?></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <form method="post" class="mb-4">
+      <div class="row g-2 align-items-end">
+        <div class="col-sm-4 col-md-3 col-lg-2">
+          <label class="form-label">Date</label>
+          <input type="date" name="payment_date" class="form-control" value="<?= htmlspecialchars($paymentDateValue) ?>" required>
+        </div>
+        <div class="col-sm-4 col-md-3 col-lg-2">
+          <label class="form-label">Amount</label>
+          <input type="number" step="0.01" min="0" name="amount" class="form-control" value="<?= htmlspecialchars($amountValue) ?>" placeholder="0.00" required>
+        </div>
+        <div class="col-sm-4 col-md-3 col-lg-2">
+          <button class="btn btn-primary w-100">Add Payment</button>
+        </div>
       </div>
     </form>
 
-    <ul class="nav nav-tabs" id="paymentTabs" role="tablist">
-      <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="received-tab" data-bs-toggle="tab" data-bs-target="#received" type="button" role="tab">Received</button>
-      </li>
-      <li class="nav-item" role="presentation">
-        <button class="nav-link" id="pending-tab" data-bs-toggle="tab" data-bs-target="#pending" type="button" role="tab">Pending</button>
-      </li>
-    </ul>
-    <div class="tab-content mt-3">
-      <div class="tab-pane fade show active" id="received" role="tabpanel">
-        <?php if (!empty($receivedPayments)): ?>
-        <table class="table table-bordered">
-          <thead>
-            <tr>
-              <th>Date</th>
-              <th>Amount</th>
-              <th>Episode + Treatment</th>
-              <th>Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            <?php foreach ($receivedPayments as $pay): ?>
-            <tr>
-              <td><?= htmlspecialchars($pay['payment_date']) ?></td>
-              <td><?= htmlspecialchars($pay['amount']) ?></td>
-              <td><?= htmlspecialchars($pay['episodes_covered'] . ' / ' . $pay['treatment_covered']) ?></td>
-              <td>
-                <a href="?patient_id=<?= $patientId ?>&edit=<?= $pay['id'] ?>" class="btn btn-sm btn-primary">Edit</a>
-                <a href="?patient_id=<?= $patientId ?>&delete=<?= $pay['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete payment?');">Delete</a>
-              </td>
-            </tr>
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped align-middle">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Amount</th>
+            <th>Status</th>
+            <th>Episode</th>
+            <th>Details</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php if (!empty($allPayments)): ?>
+            <?php foreach ($allPayments as $pay): ?>
+              <?php
+                $episodeDisplay = $pay['episodes_covered'] ? 'Episode ' . $pay['episodes_covered'] : '-';
+                if ($pay['status'] === 'credit') {
+                    $details = 'Credit Balance';
+                } elseif (!empty($pay['treatment_covered'])) {
+                    $details = 'Session ' . $pay['treatment_covered'];
+                } else {
+                    $details = 'Manual Payment';
+                }
+                $statusClass = [
+                    'pending' => 'bg-warning text-dark',
+                    'received' => 'bg-success',
+                    'credit' => 'bg-info text-dark',
+                ][$pay['status']] ?? 'bg-secondary';
+              ?>
+              <tr>
+                <td><?= htmlspecialchars($pay['payment_date']) ?></td>
+                <td>R <?= number_format((float) $pay['amount'], 2) ?></td>
+                <td><span class="badge <?= $statusClass ?>"><?= ucfirst(htmlspecialchars($pay['status'])) ?></span></td>
+                <td><?= htmlspecialchars($episodeDisplay) ?></td>
+                <td><?= htmlspecialchars($details) ?></td>
+                <td>
+                  <a href="?patient_id=<?= $patientId ?>&delete=<?= $pay['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete payment?');">Delete</a>
+                </td>
+              </tr>
             <?php endforeach; ?>
-          </tbody>
-        </table>
-        <?php else: ?>
-          <p>No received payments recorded.</p>
-        <?php endif; ?>
-      </div>
-      <div class="tab-pane fade" id="pending" role="tabpanel">
-        <?php if (!empty($pendingPayments)): ?>
-        <table class="table table-bordered">
-          <thead>
+          <?php else: ?>
             <tr>
-              <th>Date</th>
-              <th>Amount</th>
-              <th>Episode + Treatment</th>
-              <th>Action</th>
+              <td colspan="6" class="text-center">No payment records available.</td>
             </tr>
-          </thead>
-          <tbody>
-            <?php foreach ($pendingPayments as $pay): ?>
-            <tr>
-              <td><?= htmlspecialchars($pay['payment_date']) ?></td>
-              <td><?= htmlspecialchars($pay['amount']) ?></td>
-              <td><?= htmlspecialchars($pay['episodes_covered'] . ' / ' . $pay['treatment_covered']) ?></td>
-              <td>
-                <a href="?patient_id=<?= $patientId ?>&edit=<?= $pay['id'] ?>" class="btn btn-sm btn-primary">Edit</a>
-                <a href="?patient_id=<?= $patientId ?>&delete=<?= $pay['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete payment?');">Delete</a>
-              </td>
-            </tr>
-            <?php endforeach; ?>
-          </tbody>
-        </table>
-        <?php else: ?>
-          <p>No pending payments.</p>
-        <?php endif; ?>
-      </div>
+          <?php endif; ?>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>
-
-<script>
-  const episodeSelect = document.getElementById('episodeSelect');
-  const sessionSelect = document.getElementById('sessionSelect');
-
-  function filterSessions() {
-    const ep = episodeSelect.value;
-    Array.from(sessionSelect.options).forEach(opt => {
-      if (!opt.value) return;
-      opt.hidden = ep && opt.dataset.episode !== ep;
-    });
-  }
-
-  episodeSelect?.addEventListener('change', filterSessions);
-  filterSessions();
-</script>
 
 <?php include '../../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add ledger helpers in `PaymentController` to track credit balances, reapply manual payments, and use credit when new sessions are recorded
- simplify the Manage Payments form, surface total pending/credit, and show all payment rows in a single table with status badges

## Testing
- php -l controllers/PaymentController.php
- php -l views/shared/manage_payments.php

------
https://chatgpt.com/codex/tasks/task_e_68ce8ecbce9483229952cf886cca330a