### PR TITLE
Refactor payment ledger and credit handling

### DIFF
--- a/config/payments.sql
+++ b/config/payments.sql
@@ -1,12 +1,23 @@
-CREATE TABLE IF NOT EXISTS payments (
+DROP TABLE IF EXISTS payments;
+
+CREATE TABLE IF NOT EXISTS patient_payment_ledger (
     id INT AUTO_INCREMENT PRIMARY KEY,
     patient_id INT NOT NULL,
-    payment_date DATE NOT NULL,
+    transaction_date DATE NOT NULL,
+    transaction_type ENUM('charge', 'payment') NOT NULL,
     amount DECIMAL(10,2) NOT NULL,
-    episodes_covered INT DEFAULT 0,
-    treatment_covered VARCHAR(255) DEFAULT NULL,
-    status ENUM('received','pending') NOT NULL,
+    status ENUM('pending', 'received') NOT NULL DEFAULT 'pending',
+    episode_id INT DEFAULT NULL,
+    session_reference VARCHAR(100) DEFAULT NULL,
+    notes VARCHAR(255) DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (patient_id) REFERENCES patients(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS patient_credit_balances (
+    patient_id INT PRIMARY KEY,
+    credit_amount DECIMAL(10,2) NOT NULL DEFAULT 0.00,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (patient_id) REFERENCES patients(id) ON DELETE CASCADE
 );

--- a/controllers/PaymentController.php
+++ b/controllers/PaymentController.php
@@ -6,71 +6,83 @@ class PaymentController {
         $this->pdo = $pdo;
     }
 
-    public function getPaymentsByPatient($patientId, $status) {
-        $stmt = $this->pdo->prepare("SELECT * FROM payments WHERE patient_id = ? AND status = ? ORDER BY payment_date DESC, id DESC");
-        $stmt->execute([$patientId, $status]);
+    public function getPaymentsByPatient($patientId, $status = null) {
+        $sql = "SELECT * FROM patient_payment_ledger WHERE patient_id = ?";
+        $params = [$patientId];
+
+        if ($status !== null && $status !== '') {
+            $sql .= " AND status = ?";
+            $params[] = $status;
+        }
+
+        $sql .= " ORDER BY transaction_date DESC, id DESC";
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     public function getAllPaymentsByPatient($patientId) {
-        $stmt = $this->pdo->prepare("SELECT * FROM payments WHERE patient_id = ? ORDER BY payment_date DESC, id DESC");
+        $stmt = $this->pdo->prepare(
+            "SELECT * FROM patient_payment_ledger WHERE patient_id = ? ORDER BY transaction_date DESC, id DESC"
+        );
         $stmt->execute([$patientId]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     public function getPatientTotals($patientId) {
-        $stmt = $this->pdo->prepare("SELECT status, SUM(amount) AS total FROM payments WHERE patient_id = ? GROUP BY status");
-        $stmt->execute([$patientId]);
-        $totals = [
-            'pending' => 0.0,
-            'credit' => 0.0,
+        $pendingStmt = $this->pdo->prepare(
+            "SELECT SUM(amount) AS total FROM patient_payment_ledger WHERE patient_id = ? AND transaction_type = 'charge' AND status = 'pending'"
+        );
+        $pendingStmt->execute([$patientId]);
+        $pending = $pendingStmt->fetchColumn();
+
+        return [
+            'pending' => $pending !== false ? (float) $pending : 0.0,
+            'credit' => $this->getCreditBalance($patientId),
         ];
-        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
-            if (isset($totals[$row['status']])) {
-                $totals[$row['status']] = (float) $row['total'];
-            }
-        }
-        return $totals;
     }
 
     public function getPaymentById($id) {
-        $stmt = $this->pdo->prepare("SELECT * FROM payments WHERE id = ?");
+        $stmt = $this->pdo->prepare("SELECT * FROM patient_payment_ledger WHERE id = ?");
         $stmt->execute([$id]);
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
 
-    public function savePayment($data) {
+    public function savePayment(array $data) {
+        $patientId = (int) ($data['patient_id'] ?? 0);
+        $amount = isset($data['amount']) ? (float) $data['amount'] : 0.0;
+        $transactionDate = $data['payment_date'] ?? $data['transaction_date'] ?? date('Y-m-d');
+        $transactionType = $data['transaction_type'] ?? 'payment';
+        $episodeId = $data['episode_id'] ?? ($data['episodes_covered'] ?? null);
+        $sessionReference = $data['session_reference'] ?? ($data['treatment_covered'] ?? null);
+        $notes = $data['notes'] ?? null;
+
+        if ($patientId <= 0 || $amount <= 0) {
+            throw new InvalidArgumentException('Invalid payment data.');
+        }
+
+        if (!in_array($transactionType, ['charge', 'payment'], true)) {
+            throw new InvalidArgumentException('Invalid transaction type.');
+        }
+
+        $initialStatus = $transactionType === 'payment' ? 'received' : 'pending';
+
         $this->pdo->beginTransaction();
         try {
-            if (!empty($data['id'])) {
-                $sql = "UPDATE payments SET payment_date = :payment_date, amount = :amount, episodes_covered = :episodes_covered, treatment_covered = :treatment_covered, status = :status, updated_at = NOW() WHERE id = :id";
-                $stmt = $this->pdo->prepare($sql);
-                $stmt->bindValue(':payment_date', $data['payment_date']);
-                $stmt->bindValue(':amount', $data['amount']);
-                $this->bindNullable($stmt, ':episodes_covered', $data['episodes_covered'], PDO::PARAM_INT);
-                $this->bindNullable($stmt, ':treatment_covered', $data['treatment_covered'], PDO::PARAM_STR);
-                $stmt->bindValue(':status', $data['status']);
-                $stmt->bindValue(':id', $data['id'], PDO::PARAM_INT);
-                $stmt->execute();
-                $this->pdo->commit();
-                return;
-            }
-
-            $sql = "INSERT INTO payments (patient_id, payment_date, amount, episodes_covered, treatment_covered, status, created_at, updated_at) VALUES (:patient_id, :payment_date, :amount, :episodes_covered, :treatment_covered, 'received', NOW(), NOW())";
+            $sql = "INSERT INTO patient_payment_ledger (patient_id, transaction_date, amount, transaction_type, status, episode_id, session_reference, notes, created_at, updated_at) VALUES (:patient_id, :transaction_date, :amount, :transaction_type, :status, :episode_id, :session_reference, :notes, NOW(), NOW())";
             $stmt = $this->pdo->prepare($sql);
-            $stmt->bindValue(':patient_id', $data['patient_id'], PDO::PARAM_INT);
-            $stmt->bindValue(':payment_date', $data['payment_date']);
-            $stmt->bindValue(':amount', $data['amount']);
-            $this->bindNullable($stmt, ':episodes_covered', $data['episodes_covered'], PDO::PARAM_INT);
-            $this->bindNullable($stmt, ':treatment_covered', $data['treatment_covered'], PDO::PARAM_STR);
+            $stmt->bindValue(':patient_id', $patientId, PDO::PARAM_INT);
+            $stmt->bindValue(':transaction_date', $transactionDate);
+            $stmt->bindValue(':amount', $amount);
+            $stmt->bindValue(':transaction_type', $transactionType);
+            $stmt->bindValue(':status', $initialStatus);
+            $this->bindNullable($stmt, ':episode_id', $episodeId, PDO::PARAM_INT);
+            $this->bindNullable($stmt, ':session_reference', $sessionReference, PDO::PARAM_STR);
+            $this->bindNullable($stmt, ':notes', $notes, PDO::PARAM_STR);
             $stmt->execute();
 
-            $amount = (float) $data['amount'];
-            $remaining = $this->applyAmountToPending($data['patient_id'], $amount);
-            if ($remaining > 0) {
-                $this->storeCredit($data['patient_id'], $remaining, $data['payment_date']);
-                $this->applyCreditsToPending($data['patient_id']);
-            }
+            $this->recalculateLedgerForPatient($patientId);
 
             $this->pdo->commit();
         } catch (Exception $e) {
@@ -79,47 +91,22 @@ class PaymentController {
         }
     }
 
-    /**
-     * Record payment information for a treatment session and automatically
-     * apply available credit to mark the session as received when possible.
-     */
     public function recordSessionPayment($patientId, $episodeId, $sessionDate, $amount) {
-        $this->pdo->beginTransaction();
-        $committed = false;
-        try {
-            $stmt = $this->pdo->prepare(
-                "SELECT id FROM payments WHERE patient_id = ? AND episodes_covered = ? AND treatment_covered = ?"
-            );
-            $stmt->execute([$patientId, $episodeId, $sessionDate]);
-            $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+        $data = [
+            'patient_id' => $patientId,
+            'payment_date' => $sessionDate,
+            'amount' => $amount,
+            'transaction_type' => 'charge',
+            'episode_id' => $episodeId,
+            'session_reference' => $sessionDate,
+            'notes' => 'Session charge',
+        ];
 
-            if ($existing) {
-                $update = $this->pdo->prepare(
-                    "UPDATE payments SET payment_date = ?, amount = ?, status = 'pending', updated_at = NOW() WHERE id = ?"
-                );
-                $update->execute([$sessionDate, $amount, $existing['id']]);
-            } else {
-                $insert = $this->pdo->prepare(
-                    "INSERT INTO payments (patient_id, payment_date, amount, episodes_covered, treatment_covered, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'pending', NOW(), NOW())"
-                );
-                $insert->execute([$patientId, $sessionDate, $amount, $episodeId, $sessionDate]);
-            }
-
-            $this->applyCreditsToPending($patientId);
-            $this->pdo->commit();
-            $committed = true;
-        } catch (Exception $e) {
-            $this->pdo->rollBack();
-            throw $e;
-        }
-
-        if ($committed) {
-            $this->rebuildPatientLedger($patientId);
-        }
+        $this->savePayment($data);
     }
 
     public function deletePayment($id) {
-        $stmt = $this->pdo->prepare("SELECT patient_id FROM payments WHERE id = ?");
+        $stmt = $this->pdo->prepare("SELECT patient_id FROM patient_payment_ledger WHERE id = ?");
         $stmt->execute([$id]);
         $patientId = $stmt->fetchColumn();
 
@@ -127,10 +114,65 @@ class PaymentController {
             return;
         }
 
-        $delete = $this->pdo->prepare("DELETE FROM payments WHERE id = ?");
-        $delete->execute([$id]);
+        $this->pdo->beginTransaction();
+        try {
+            $delete = $this->pdo->prepare("DELETE FROM patient_payment_ledger WHERE id = ?");
+            $delete->execute([$id]);
 
-        $this->rebuildPatientLedger($patientId);
+            $this->recalculateLedgerForPatient((int) $patientId);
+
+            $this->pdo->commit();
+        } catch (Exception $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    private function recalculateLedgerForPatient($patientId) {
+        $stmt = $this->pdo->prepare(
+            "SELECT id, transaction_type, amount FROM patient_payment_ledger WHERE patient_id = ? ORDER BY transaction_date ASC, id ASC"
+        );
+        $stmt->execute([$patientId]);
+        $entries = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $credit = 0.0;
+        $updateStmt = $this->pdo->prepare(
+            "UPDATE patient_payment_ledger SET status = ?, updated_at = NOW() WHERE id = ?"
+        );
+
+        foreach ($entries as $entry) {
+            $amount = (float) $entry['amount'];
+            if ($entry['transaction_type'] === 'payment') {
+                $status = 'received';
+                $credit += $amount;
+            } else {
+                if ($credit + 1e-6 >= $amount) {
+                    $status = 'received';
+                    $credit -= $amount;
+                } else {
+                    $status = 'pending';
+                }
+            }
+
+            $updateStmt->execute([$status, $entry['id']]);
+        }
+
+        $this->upsertCreditBalance($patientId, $credit);
+    }
+
+    private function getCreditBalance($patientId) {
+        $stmt = $this->pdo->prepare("SELECT credit_amount FROM patient_credit_balances WHERE patient_id = ?");
+        $stmt->execute([$patientId]);
+        $credit = $stmt->fetchColumn();
+
+        return $credit !== false ? (float) $credit : 0.0;
+    }
+
+    private function upsertCreditBalance($patientId, $amount) {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO patient_credit_balances (patient_id, credit_amount, updated_at) VALUES (?, ?, NOW()) ON DUPLICATE KEY UPDATE credit_amount = VALUES(credit_amount), updated_at = NOW()"
+        );
+        $stmt->execute([$patientId, max(0, $amount)]);
     }
 
     private function bindNullable($stmt, $param, $value, $type) {
@@ -139,115 +181,6 @@ class PaymentController {
         } else {
             $stmt->bindValue($param, $value, $type);
         }
-    }
-
-    private function applyAmountToPending($patientId, $amount) {
-        $amount = (float) $amount;
-        if ($amount <= 0) {
-            return 0.0;
-        }
-
-        $pendingStmt = $this->pdo->prepare(
-            "SELECT id, amount FROM payments WHERE patient_id = ? AND status = 'pending' ORDER BY payment_date ASC, id ASC"
-        );
-        $pendingStmt->execute([$patientId]);
-        $pending = $pendingStmt->fetchAll(PDO::FETCH_ASSOC);
-
-        foreach ($pending as $row) {
-            if ($amount <= 0) {
-                break;
-            }
-            $due = (float) $row['amount'];
-            if ($due <= 0) {
-                continue;
-            }
-
-            if ($amount + 1e-6 >= $due) {
-                $update = $this->pdo->prepare("UPDATE payments SET status = 'received', updated_at = NOW() WHERE id = ?");
-                $update->execute([$row['id']]);
-                $amount -= $due;
-            }
-        }
-
-        return $amount;
-    }
-
-    private function storeCredit($patientId, $amount, $paymentDate) {
-        if ($amount <= 0) {
-            return;
-        }
-
-        $stmt = $this->pdo->prepare("SELECT id, amount FROM payments WHERE patient_id = ? AND status = 'credit' ORDER BY payment_date ASC, id ASC LIMIT 1");
-        $stmt->execute([$patientId]);
-        $existing = $stmt->fetch(PDO::FETCH_ASSOC);
-
-        if ($existing) {
-            $newAmount = (float) $existing['amount'] + $amount;
-            $update = $this->pdo->prepare("UPDATE payments SET amount = ?, payment_date = ?, updated_at = NOW() WHERE id = ?");
-            $update->execute([$newAmount, $paymentDate, $existing['id']]);
-        } else {
-            $insert = $this->pdo->prepare("INSERT INTO payments (patient_id, payment_date, amount, episodes_covered, treatment_covered, status, created_at, updated_at) VALUES (?, ?, ?, NULL, NULL, 'credit', NOW(), NOW())");
-            $insert->execute([$patientId, $paymentDate, $amount]);
-        }
-    }
-
-    private function applyCreditsToPending($patientId) {
-        $creditStmt = $this->pdo->prepare("SELECT id, amount, payment_date FROM payments WHERE patient_id = ? AND status = 'credit' ORDER BY payment_date ASC, id ASC");
-        $creditStmt->execute([$patientId]);
-        $credits = $creditStmt->fetchAll(PDO::FETCH_ASSOC);
-
-        foreach ($credits as $credit) {
-            $available = (float) $credit['amount'];
-            if ($available <= 0) {
-                $delete = $this->pdo->prepare("DELETE FROM payments WHERE id = ?");
-                $delete->execute([$credit['id']]);
-                continue;
-            }
-
-            $remaining = $this->applyAmountToPending($patientId, $available);
-            if ($remaining <= 1e-6) {
-                $delete = $this->pdo->prepare("DELETE FROM payments WHERE id = ?");
-                $delete->execute([$credit['id']]);
-            } else {
-                $update = $this->pdo->prepare("UPDATE payments SET amount = ?, updated_at = NOW() WHERE id = ?");
-                $update->execute([$remaining, $credit['id']]);
-            }
-        }
-    }
-
-    private function rebuildPatientLedger($patientId) {
-        $this->pdo->beginTransaction();
-        try {
-            $this->pdo->prepare("DELETE FROM payments WHERE patient_id = ? AND status = 'credit'")->execute([$patientId]);
-
-            $reset = $this->pdo->prepare("UPDATE payments SET status = 'pending' WHERE patient_id = ? AND treatment_covered IS NOT NULL");
-            $reset->execute([$patientId]);
-
-            $paymentsStmt = $this->pdo->prepare("SELECT payment_date, amount FROM payments WHERE patient_id = ? AND treatment_covered IS NULL AND status != 'credit' ORDER BY payment_date ASC, id ASC");
-            $paymentsStmt->execute([$patientId]);
-            $payments = $paymentsStmt->fetchAll(PDO::FETCH_ASSOC);
-
-            $credit = 0.0;
-            foreach ($payments as $payment) {
-                $credit += $this->applyPaymentAndReturnRemaining($patientId, (float) $payment['amount']);
-            }
-
-            if ($credit > 0) {
-                $lastDate = !empty($payments) ? end($payments)['payment_date'] : date('Y-m-d');
-                $this->storeCredit($patientId, $credit, $lastDate);
-                $this->applyCreditsToPending($patientId);
-            }
-
-            $this->pdo->commit();
-        } catch (Exception $e) {
-            $this->pdo->rollBack();
-            throw $e;
-        }
-    }
-
-    private function applyPaymentAndReturnRemaining($patientId, $amount) {
-        $remaining = $this->applyAmountToPending($patientId, $amount);
-        return $remaining;
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- drop the legacy `payments` table and introduce ledger plus credit balance tables for the new workflow
- rebuild the payment controller to recalculate ledger statuses and maintain the patient credit balance
- refresh the doctor and shared payment views so charges and payments honour credit availability

## Testing
- php -l controllers/PaymentController.php
- php -l views/shared/manage_payments.php
- php -l views/doctor/start_treatment.php

------
https://chatgpt.com/codex/tasks/task_e_68ce99e0451c8322bf6912567a25595f