### PR TITLE
Fix admin edit modals after responsive update

### DIFF
--- a/views/admin/manage_exercises.php
+++ b/views/admin/manage_exercises.php
@@ -99,12 +99,16 @@ include '../../includes/header.php';
                         </td>
                         <td class="text-end">
                             <div class="d-flex flex-wrap justify-content-end gap-2">
-                                <button class="btn btn-sm btn-info" onclick="openEditModal(
-                                    <?= (int) $ex['id'] ?>,
-                                    <?= json_encode($ex['name']) ?>,
-                                    <?= json_encode($ex['default_reps']) ?>,
-                                    <?= json_encode($ex['default_duration_minutes']) ?>
-                                )">Edit</button>
+                                <button
+                                    type="button"
+                                    class="btn btn-sm btn-info"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#editModal"
+                                    data-id="<?= (int) $ex['id'] ?>"
+                                    data-name="<?= htmlspecialchars($ex['name'], ENT_QUOTES, 'UTF-8') ?>"
+                                    data-default-reps="<?= htmlspecialchars((string) $ex['default_reps'], ENT_QUOTES, 'UTF-8') ?>"
+                                    data-default-duration="<?= htmlspecialchars((string) $ex['default_duration_minutes'], ENT_QUOTES, 'UTF-8') ?>"
+                                >Edit</button>
                                 <form method="POST" class="d-inline">
                                     <input type="hidden" name="action" value="toggle_exercise">
                                     <input type="hidden" name="id" value="<?= (int) $ex['id'] ?>">
@@ -172,14 +176,24 @@ include '../../includes/header.php';
 </div>
 
 <script>
-function openEditModal(id, name, default_reps, default_duration_minutes) {
-  document.getElementById('edit_id').value = id;
-  document.getElementById('edit_name').value = name;
-  document.getElementById('edit_default_reps').value = default_reps;
-  document.getElementById('edit_default_duration_minutes').value = default_duration_minutes;
-  const modal = new bootstrap.Modal(document.getElementById('editModal'));
-  modal.show();
-}
+document.addEventListener('DOMContentLoaded', function () {
+    var editExerciseModal = document.getElementById('editModal');
+    if (!editExerciseModal) {
+        return;
+    }
+
+    editExerciseModal.addEventListener('show.bs.modal', function (event) {
+        var button = event.relatedTarget;
+        if (!button) {
+            return;
+        }
+
+        document.getElementById('edit_id').value = button.getAttribute('data-id') || '';
+        document.getElementById('edit_name').value = button.getAttribute('data-name') || '';
+        document.getElementById('edit_default_reps').value = button.getAttribute('data-default-reps') || '';
+        document.getElementById('edit_default_duration_minutes').value = button.getAttribute('data-default-duration') || '';
+    });
+});
 </script>
 
 <?php include '../../includes/footer.php'; ?>

--- a/views/admin/manage_referrals.php
+++ b/views/admin/manage_referrals.php
@@ -85,11 +85,15 @@ include '../../includes/header.php';
                         <td><?= htmlspecialchars($r['type']) ?></td>
                         <td class="text-end">
                             <div class="d-flex flex-wrap justify-content-end gap-2">
-                                <button class="btn btn-sm btn-info" onclick="openEditModal(
-                                    <?= (int) $r['id'] ?>,
-                                    <?= json_encode($r['name']) ?>,
-                                    <?= json_encode($r['type']) ?>
-                                )">Edit</button>
+                                <button
+                                    type="button"
+                                    class="btn btn-sm btn-info"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#editModal"
+                                    data-id="<?= (int) $r['id'] ?>"
+                                    data-name="<?= htmlspecialchars($r['name'], ENT_QUOTES, 'UTF-8') ?>"
+                                    data-type="<?= htmlspecialchars($r['type'], ENT_QUOTES, 'UTF-8') ?>"
+                                >Edit</button>
                                 <form method="POST" class="d-inline" onsubmit="return confirm('Delete this referral?')">
                                     <input type="hidden" name="action" value="delete_referral">
                                     <input type="hidden" name="id" value="<?= (int) $r['id'] ?>">
@@ -151,13 +155,23 @@ include '../../includes/header.php';
 </div>
 
 <script>
-function openEditModal(id, name, type) {
-  document.getElementById('edit_id').value = id;
-  document.getElementById('edit_name').value = name;
-  document.getElementById('edit_type').value = type;
-  const modal = new bootstrap.Modal(document.getElementById('editModal'));
-  modal.show();
-}
+document.addEventListener('DOMContentLoaded', function () {
+    var editReferralModal = document.getElementById('editModal');
+    if (!editReferralModal) {
+        return;
+    }
+
+    editReferralModal.addEventListener('show.bs.modal', function (event) {
+        var button = event.relatedTarget;
+        if (!button) {
+            return;
+        }
+
+        document.getElementById('edit_id').value = button.getAttribute('data-id') || '';
+        document.getElementById('edit_name').value = button.getAttribute('data-name') || '';
+        document.getElementById('edit_type').value = button.getAttribute('data-type') || '';
+    });
+});
 </script>
 
 <?php include '../../includes/footer.php'; ?>

--- a/views/admin/manage_users.php
+++ b/views/admin/manage_users.php
@@ -114,12 +114,16 @@ include '../../includes/header.php';
                         <td class="text-end">
                             <div class="d-flex flex-wrap justify-content-end gap-2">
                                 <?php if (!isset($_GET['show_deleted'])): ?>
-                                <button class="btn btn-sm btn-info" onclick="openEditModal(
-                                    <?= (int) $u['id'] ?>,
-                                    <?= json_encode($u['name']) ?>,
-                                    <?= json_encode($u['email']) ?>,
-                                    <?= json_encode($u['role']) ?>
-                                )">Edit</button>
+                                <button
+                                    type="button"
+                                    class="btn btn-sm btn-info"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#editUserModal"
+                                    data-id="<?= (int) $u['id'] ?>"
+                                    data-name="<?= htmlspecialchars($u['name'], ENT_QUOTES, 'UTF-8') ?>"
+                                    data-email="<?= htmlspecialchars($u['email'], ENT_QUOTES, 'UTF-8') ?>"
+                                    data-role="<?= htmlspecialchars($u['role'], ENT_QUOTES, 'UTF-8') ?>"
+                                >Edit</button>
 
                                 <form method="POST" class="d-inline">
                                     <input type="hidden" name="action" value="toggle_user_status">
@@ -199,14 +203,24 @@ include '../../includes/header.php';
 </div>
 
 <script>
-function openEditModal(id, name, email, role) {
-    document.getElementById('edit_id').value = id;
-    document.getElementById('edit_name').value = name;
-    document.getElementById('edit_email').value = email;
-    document.getElementById('edit_role').value = role;
-    const modal = new bootstrap.Modal(document.getElementById('editUserModal'));
-    modal.show();
-}
+document.addEventListener('DOMContentLoaded', function () {
+    var editUserModal = document.getElementById('editUserModal');
+    if (!editUserModal) {
+        return;
+    }
+
+    editUserModal.addEventListener('show.bs.modal', function (event) {
+        var button = event.relatedTarget;
+        if (!button) {
+            return;
+        }
+
+        document.getElementById('edit_id').value = button.getAttribute('data-id') || '';
+        document.getElementById('edit_name').value = button.getAttribute('data-name') || '';
+        document.getElementById('edit_email').value = button.getAttribute('data-email') || '';
+        document.getElementById('edit_role').value = button.getAttribute('data-role') || '';
+    });
+});
 </script>
 
 <?php include '../../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- replace inline modal trigger logic with data attributes and Bootstrap event handlers on admin management pages
- sanitize values for modal population and ensure edit buttons no longer submit forms by default

## Testing
- php -l views/admin/manage_users.php
- php -l views/admin/manage_exercises.php
- php -l views/admin/manage_referrals.php

------
https://chatgpt.com/codex/tasks/task_e_68cfe1e0bafc8322a38b3f97c5028e5d