### PR TITLE
Restore custom exercise input for Others selection

### DIFF
--- a/views/doctor/start_treatment.php
+++ b/views/doctor/start_treatment.php
@@ -248,10 +248,6 @@ include '../../includes/header.php';
 
     container.appendChild(row);
     updateExerciseOptions();
-    row.querySelector('.exercise-select').addEventListener('change', function(){
-      handleExerciseChange(this);
-      updateExerciseOptions();
-    });
   }
 
   function updateExerciseOptions() {
@@ -259,6 +255,7 @@ include '../../includes/header.php';
     const selectedValues = Array.from(selects).map(s => s.value).filter(v => v && v !== 'other');
     selects.forEach(sel => {
       const currentValue = sel.value;
+      $(sel).off('change.exercise');
       if ($(sel).data('select2')) {
         $(sel).select2('destroy');
       }
@@ -269,9 +266,11 @@ include '../../includes/header.php';
         }).join('') + '<option value="other">Others</option>';
       sel.value = currentValue;
       $(sel).select2({width: '100%'});
-      if(sel.value === 'other'){
-        handleExerciseChange(sel);
-      }
+      $(sel).on('change.exercise', function(){
+        handleExerciseChange(this);
+        updateExerciseOptions();
+      });
+      handleExerciseChange(sel);
     });
   }
 


### PR DESCRIPTION
## Summary
- reinitialize exercise selects with namespaced change handlers so the Others option keeps its custom name field
- ensure the custom exercise name input is toggled on every refresh to preserve responsive behaviour

## Testing
- php -l views/doctor/start_treatment.php

------
https://chatgpt.com/codex/tasks/task_e_68cfe3bbded883228f45450c7836f757