### PR TITLE
Add therapist assignments and additional notes to treatment sessions

### DIFF
--- a/config/update_treatment_sessions_add_therapist_fields.sql
+++ b/config/update_treatment_sessions_add_therapist_fields.sql
@@ -1,0 +1,21 @@
+-- Add therapist assignments and additional notes to treatment sessions
+ALTER TABLE treatment_sessions
+  ADD COLUMN primary_therapist_id INT NULL AFTER doctor_id,
+  ADD COLUMN secondary_therapist_id INT NULL AFTER primary_therapist_id,
+  ADD COLUMN additional_treatment_notes TEXT NULL AFTER advise;
+
+-- Backfill primary therapist with the doctor who logged the session
+UPDATE treatment_sessions
+SET primary_therapist_id = doctor_id
+WHERE primary_therapist_id IS NULL;
+
+-- Make primary therapist mandatory for all future rows
+ALTER TABLE treatment_sessions
+  MODIFY COLUMN primary_therapist_id INT NOT NULL;
+
+-- Optional: enforce referential integrity with the users table
+ALTER TABLE treatment_sessions
+  ADD CONSTRAINT fk_treatment_sessions_primary_therapist FOREIGN KEY (primary_therapist_id) REFERENCES users(id);
+
+ALTER TABLE treatment_sessions
+  ADD CONSTRAINT fk_treatment_sessions_secondary_therapist FOREIGN KEY (secondary_therapist_id) REFERENCES users(id);


### PR DESCRIPTION
## Summary
- load active doctors for therapist selection in the treatment session form and require a unique primary therapist
- persist primary/secondary therapist assignments and additional treatment notes while showing them in the session history
- provide SQL statements to extend the treatment_sessions table with therapist fields and additional notes

## Testing
- php -l views/doctor/start_treatment.php
- php -l controllers/TreatmentController.php

------
https://chatgpt.com/codex/tasks/task_e_68d2daec4f4c8322a6b77ce3c19d8a35