### PR TITLE
Add treatment session deletion workflow with payment cleanup

### DIFF
--- a/views/doctor/save_treatment.php
+++ b/views/doctor/save_treatment.php
@@ -23,11 +23,14 @@ if (
 
     $result = $treatmentController->saveSession($data);
 
-    if ($result === true) {
+    if (is_array($result) && !empty($result['success'])) {
         header("Location: ../views/doctor/doctor_dashboard.php?msg=Treatment+saved");
         exit;
     } else {
-        echo "Error saving treatment: " . htmlspecialchars($result);
+        $errorMessage = is_array($result) && isset($result['error'])
+            ? $result['error']
+            : (is_string($result) ? $result : 'Unable to save the treatment session.');
+        echo "Error saving treatment: " . htmlspecialchars($errorMessage);
     }
 } else {
     echo "Invalid access or missing fields.";


### PR DESCRIPTION
## Summary
- allow doctors to delete treatment sessions, removing related exercise records and recalculating ledger charges
- return session identifiers from treatment saves and store charge references with those IDs for easier cleanup
- add doctor-facing delete controls with confirmation and update the legacy save endpoint to handle the new response format

## Testing
- php -l controllers/TreatmentController.php
- php -l controllers/PaymentController.php
- php -l views/doctor/start_treatment.php
- php -l views/doctor/save_treatment.php

------
https://chatgpt.com/codex/tasks/task_e_68e532b0824c8322add68dd7939bb28d