### PR TITLE
Add machine tracking to treatment sessions

### DIFF
--- a/config/treatment_machines.sql
+++ b/config/treatment_machines.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS treatment_machines (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    session_id INT NOT NULL,
+    machine_id INT NULL,
+    machine_name VARCHAR(255) DEFAULT NULL,
+    duration_minutes INT DEFAULT NULL,
+    notes TEXT DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (session_id) REFERENCES treatment_sessions(id) ON DELETE CASCADE,
+    FOREIGN KEY (machine_id) REFERENCES machines(id) ON DELETE SET NULL
+);


### PR DESCRIPTION
## Summary
- capture machines used during a treatment session alongside existing exercises
- persist machine usage in a new treatment_machines table and allow adding new machines from the session form
- surface previously used machines and support copying them into new sessions

## Testing
- php -l controllers/TreatmentController.php
- php -l views/doctor/start_treatment.php

------
https://chatgpt.com/codex/tasks/task_e_68e53efb19b483229c876055087b9dab