### PR TITLE
Add editing support for treatment sessions

### DIFF
--- a/controllers/TreatmentController.php
+++ b/controllers/TreatmentController.php
@@ -205,6 +205,325 @@ class TreatmentController {
         ];
     }
 
+    public function getSessionWithDetails($sessionId) {
+        $stmt = $this->pdo->prepare("
+            SELECT
+                ts.id,
+                ts.patient_id,
+                ts.episode_id,
+                ts.session_date,
+                ts.doctor_id,
+                ts.primary_therapist_id,
+                ts.secondary_therapist_id,
+                ts.remarks,
+                ts.progress_notes,
+                ts.advise,
+                ts.additional_treatment_notes
+            FROM treatment_sessions ts
+            WHERE ts.id = ?
+        ");
+        $stmt->execute([$sessionId]);
+
+        $session = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$session) {
+            return null;
+        }
+
+        $amountStmt = $this->pdo->prepare("
+            SELECT amount
+            FROM patient_payment_ledger
+            WHERE patient_id = :patient_id
+              AND episode_id = :episode_id
+              AND transaction_type = 'charge'
+              AND (session_reference = :session_ref OR session_reference = :session_date)
+            ORDER BY transaction_date DESC, id DESC
+            LIMIT 1
+        ");
+        $amountStmt->execute([
+            ':patient_id' => $session['patient_id'],
+            ':episode_id' => $session['episode_id'],
+            ':session_ref' => 'session:' . $session['id'],
+            ':session_date' => $session['session_date'],
+        ]);
+        $amount = $amountStmt->fetchColumn();
+
+        $exerciseStmt = $this->pdo->prepare("
+            SELECT
+                te.exercise_id,
+                te.exercise_name,
+                te.reps,
+                te.duration_minutes,
+                te.notes,
+                em.name AS master_name
+            FROM treatment_exercises te
+            LEFT JOIN exercises_master em ON te.exercise_id = em.id
+            WHERE te.session_id = ?
+            ORDER BY te.id ASC
+        ");
+        $exerciseStmt->execute([$session['id']]);
+        $exerciseRows = $exerciseStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $machineStmt = $this->pdo->prepare("
+            SELECT
+                tm.machine_id,
+                tm.machine_name,
+                tm.duration_minutes,
+                tm.notes,
+                m.name AS master_name
+            FROM treatment_machines tm
+            LEFT JOIN machines m ON tm.machine_id = m.id
+            WHERE tm.session_id = ?
+            ORDER BY tm.id ASC
+        ");
+        $machineStmt->execute([$session['id']]);
+        $machineRows = $machineStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $session['primary_therapist_id'] = $session['primary_therapist_id'] !== null
+            ? (int) $session['primary_therapist_id']
+            : null;
+        $session['secondary_therapist_id'] = $session['secondary_therapist_id'] !== null
+            ? (int) $session['secondary_therapist_id']
+            : null;
+        $session['amount'] = $amount !== false ? (string) $amount : null;
+
+        $session['exercises'] = array_map(function ($row) {
+            return [
+                'exercise_id' => $row['exercise_id'] !== null ? (int) $row['exercise_id'] : null,
+                'name' => $row['master_name'] ?? $row['exercise_name'] ?? '',
+                'exercise_name' => $row['exercise_name'] ?? '',
+                'reps' => $row['reps'],
+                'duration_minutes' => $row['duration_minutes'],
+                'notes' => $row['notes'],
+            ];
+        }, $exerciseRows);
+
+        $session['machines'] = array_map(function ($row) {
+            return [
+                'machine_id' => $row['machine_id'] !== null ? (int) $row['machine_id'] : null,
+                'name' => $row['master_name'] ?? $row['machine_name'] ?? '',
+                'machine_name' => $row['machine_name'] ?? '',
+                'duration_minutes' => $row['duration_minutes'],
+                'notes' => $row['notes'],
+            ];
+        }, $machineRows);
+
+        return $session;
+    }
+
+    public function updateSession($sessionId, array $data) {
+        $existingStmt = $this->pdo->prepare(
+            "SELECT patient_id, episode_id FROM treatment_sessions WHERE id = ?"
+        );
+        $existingStmt->execute([$sessionId]);
+        $existing = $existingStmt->fetch(PDO::FETCH_ASSOC);
+
+        if (!$existing) {
+            return [
+                'success' => false,
+                'error' => 'Session not found.',
+            ];
+        }
+
+        if ((int) $existing['patient_id'] !== (int) $data['patient_id']
+            || (int) $existing['episode_id'] !== (int) $data['episode_id']) {
+            return [
+                'success' => false,
+                'error' => 'Session context mismatch.',
+            ];
+        }
+
+        try {
+            $this->pdo->beginTransaction();
+
+            $updateStmt = $this->pdo->prepare(
+                "UPDATE treatment_sessions"
+                . " SET session_date = :session_date,"
+                . " doctor_id = :doctor_id,"
+                . " primary_therapist_id = :primary_therapist_id,"
+                . " secondary_therapist_id = :secondary_therapist_id,"
+                . " remarks = :remarks,"
+                . " progress_notes = :progress_notes,"
+                . " advise = :advise,"
+                . " additional_treatment_notes = :additional_treatment_notes"
+                . " WHERE id = :session_id"
+            );
+            $updateStmt->execute([
+                'session_date' => $data['session_date'],
+                'doctor_id' => $data['doctor_id'],
+                'primary_therapist_id' => $data['primary_therapist_id'],
+                'secondary_therapist_id' => $data['secondary_therapist_id'],
+                'remarks' => $data['remarks'] ?? null,
+                'progress_notes' => $data['progress_notes'] ?? null,
+                'advise' => $data['advise'] ?? null,
+                'additional_treatment_notes' => isset($data['additional_treatment_notes']) && $data['additional_treatment_notes'] !== ''
+                    ? $data['additional_treatment_notes']
+                    : null,
+                'session_id' => $sessionId,
+            ]);
+
+            $deleteExercises = $this->pdo->prepare(
+                "DELETE FROM treatment_exercises WHERE session_id = ?"
+            );
+            $deleteExercises->execute([$sessionId]);
+
+            $deleteMachines = $this->pdo->prepare(
+                "DELETE FROM treatment_machines WHERE session_id = ?"
+            );
+            $deleteMachines->execute([$sessionId]);
+
+            $exerciseIds = $data['exercises']['exercise_id'] ?? [];
+            $exerciseReps = $data['exercises']['reps'] ?? [];
+            $exerciseDurations = $data['exercises']['duration_minutes'] ?? [];
+            $exerciseNotes = $data['exercises']['notes'] ?? [];
+            $exerciseNames = $data['exercises']['new_name'] ?? [];
+
+            $exerciseCount = is_array($exerciseIds) ? count($exerciseIds) : 0;
+
+            for ($i = 0; $i < $exerciseCount; $i++) {
+                $exerciseId = $exerciseIds[$i];
+                $customName = isset($exerciseNames[$i]) ? trim((string) $exerciseNames[$i]) : '';
+
+                if ($exerciseId === '' || $exerciseId === null) {
+                    if ($customName === '') {
+                        continue;
+                    }
+                    $exerciseId = 'other';
+                }
+
+                if ($exerciseId === 'other') {
+                    $name = $customName !== '' ? $customName : 'Custom Exercise';
+                    $reps = isset($exerciseReps[$i]) ? (int) $exerciseReps[$i] : 0;
+                    $duration = isset($exerciseDurations[$i]) ? (int) $exerciseDurations[$i] : 0;
+                    $stmtNew = $this->pdo->prepare(
+                        "INSERT INTO exercises_master (name, default_reps, default_duration_minutes, is_active)"
+                        . " VALUES (?, ?, ?, 1)"
+                    );
+                    $stmtNew->execute([$name, $reps, $duration]);
+                    $exerciseId = $this->pdo->lastInsertId();
+                }
+
+                if ($exerciseId === '') {
+                    continue;
+                }
+
+                $stmtEx = $this->pdo->prepare(
+                    "INSERT INTO treatment_exercises"
+                    . " (session_id, exercise_id, exercise_name, reps, duration_minutes, notes)"
+                    . " VALUES (:session_id, :exercise_id, :exercise_name, :reps, :duration_minutes, :notes)"
+                );
+                $stmtEx->execute([
+                    'session_id' => $sessionId,
+                    'exercise_id' => $exerciseId,
+                    'exercise_name' => '',
+                    'reps' => $exerciseReps[$i] ?? null,
+                    'duration_minutes' => $exerciseDurations[$i] ?? null,
+                    'notes' => $exerciseNotes[$i] ?? null,
+                ]);
+            }
+
+            $machineIds = $data['machines']['machine_id'] ?? [];
+            $machineDurations = $data['machines']['duration_minutes'] ?? [];
+            $machineNotes = $data['machines']['notes'] ?? [];
+            $machineNames = $data['machines']['new_name'] ?? [];
+
+            $machineCount = is_array($machineIds) ? count($machineIds) : 0;
+
+            $machineInsertStmt = $this->pdo->prepare(
+                "INSERT INTO treatment_machines"
+                . " (session_id, machine_id, machine_name, duration_minutes, notes)"
+                . " VALUES (:session_id, :machine_id, :machine_name, :duration_minutes, :notes)"
+            );
+
+            $machineNameLookupStmt = $this->pdo->prepare(
+                "SELECT name FROM machines WHERE id = ?"
+            );
+            $machineFindByNameStmt = $this->pdo->prepare(
+                "SELECT id FROM machines WHERE name = ? LIMIT 1"
+            );
+            $machineCreateStmt = $this->pdo->prepare(
+                "INSERT INTO machines (name, default_duration_minutes) VALUES (?, ?)"
+            );
+
+            for ($i = 0; $i < $machineCount; $i++) {
+                $rawMachineId = $machineIds[$i] ?? '';
+                $machineDuration = $machineDurations[$i] ?? null;
+                $machineNote = $machineNotes[$i] ?? null;
+                $customName = isset($machineNames[$i]) ? trim((string) $machineNames[$i]) : '';
+
+                if ($rawMachineId === '' && $customName === '') {
+                    continue;
+                }
+
+                $machineId = null;
+                $machineName = '';
+
+                if ($rawMachineId === 'other') {
+                    if ($customName === '') {
+                        throw new InvalidArgumentException('Machine name is required when selecting Other.');
+                    }
+
+                    $machineFindByNameStmt->execute([$customName]);
+                    $existingMachine = $machineFindByNameStmt->fetch(PDO::FETCH_ASSOC);
+                    if ($existingMachine) {
+                        $machineId = (int) $existingMachine['id'];
+                    } else {
+                        $defaultDuration = is_numeric($machineDuration) ? (int) $machineDuration : 0;
+                        $machineCreateStmt->execute([$customName, $defaultDuration]);
+                        $machineId = (int) $this->pdo->lastInsertId();
+                    }
+                    $machineName = $customName;
+                } else {
+                    $machineId = (int) $rawMachineId;
+                    $machineNameLookupStmt->execute([$machineId]);
+                    $foundName = $machineNameLookupStmt->fetchColumn();
+                    $machineName = $foundName !== false ? (string) $foundName : '';
+                }
+
+                if ($machineId === null) {
+                    continue;
+                }
+
+                $machineInsertStmt->execute([
+                    'session_id' => $sessionId,
+                    'machine_id' => $machineId,
+                    'machine_name' => $machineName,
+                    'duration_minutes' => $machineDuration !== '' ? $machineDuration : null,
+                    'notes' => $machineNote,
+                ]);
+            }
+
+            if (!empty($data['file']) && $data['file']['error'] === UPLOAD_ERR_OK) {
+                $uploadDir = dirname(__DIR__) . '/uploads/patient_docs/' . $data['patient_id'] . '/';
+                if (!is_dir($uploadDir)) {
+                    mkdir($uploadDir, 0777, true);
+                }
+                $original = $data['file']['name'];
+                $safeName = time() . '_' . preg_replace('/[^A-Za-z0-9.\-_]/', '_', $original);
+                move_uploaded_file($data['file']['tmp_name'], $uploadDir . $safeName);
+                $stmtFile = $this->pdo->prepare(
+                    "INSERT INTO file_master (patient_id, file_name, upload_date) VALUES (:pid, :fname, NOW())"
+                );
+                $stmtFile->execute([':pid' => $data['patient_id'], ':fname' => $safeName]);
+            }
+
+            $this->pdo->commit();
+
+            return [
+                'success' => true,
+                'session_id' => $sessionId,
+            ];
+        } catch (Exception $e) {
+            if ($this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
+
+            return [
+                'success' => false,
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
     public function deleteSessionById($sessionId) {
         $stmtExercises = $this->pdo->prepare("DELETE FROM treatment_exercises WHERE session_id = ?");
         $stmtExercises->execute([$sessionId]);


### PR DESCRIPTION
## Summary
- add controller support to load treatment sessions with their details and update existing records
- enhance the start treatment view to allow editing sessions, manage exercises/machines, and update payment charges when amounts change
- refresh the UI and client-side logic to populate editing data and highlight the active session being modified

## Testing
- php -l controllers/TreatmentController.php
- php -l views/doctor/start_treatment.php

------
https://chatgpt.com/codex/tasks/task_e_68e544d8d33083228ac7fa5b3d81714e