### PR TITLE
Add patient report file type selection and persist file_type_id

### DIFF
--- a/config/file_master.sql
+++ b/config/file_master.sql
@@ -2,7 +2,9 @@ CREATE TABLE file_master (
   file_id INT AUTO_INCREMENT PRIMARY KEY,
   patient_id INT NOT NULL,
   file_name VARCHAR(255) NOT NULL,
+  file_type_id INT NULL,
   upload_date DATETIME NOT NULL,
-  FOREIGN KEY (patient_id) REFERENCES patients(id) ON DELETE CASCADE
+  FOREIGN KEY (patient_id) REFERENCES patients(id) ON DELETE CASCADE,
+  FOREIGN KEY (file_type_id) REFERENCES patient_report_file_types(id) ON DELETE SET NULL
 );
 

--- a/config/update_file_master_add_file_type.sql
+++ b/config/update_file_master_add_file_type.sql
@@ -1,0 +1,6 @@
+ALTER TABLE file_master
+  ADD COLUMN file_type_id INT NULL AFTER file_name,
+  ADD INDEX idx_file_master_file_type_id (file_type_id),
+  ADD CONSTRAINT fk_file_master_file_type
+    FOREIGN KEY (file_type_id) REFERENCES patient_report_file_types(id)
+    ON DELETE SET NULL;

--- a/controllers/PatientController.php
+++ b/controllers/PatientController.php
@@ -26,8 +26,40 @@ class PatientController {
         $errors[] = "Valid Emergency Contact Number is required (10 digits).";
     }
 
-    if (!empty($_FILES['reports']['name'][0]) && count($_FILES['reports']['name']) > 5) {
+    $uploadedReportCount = !empty($_FILES['reports']['name'][0]) ? count($_FILES['reports']['name']) : 0;
+    if ($uploadedReportCount > 5) {
         $errors[] = "You can upload a maximum of 5 files.";
+    }
+
+    $reportFileTypeIds = $data['report_file_type_ids'] ?? [];
+    if ($uploadedReportCount > 0) {
+        if (!is_array($reportFileTypeIds) || count($reportFileTypeIds) < $uploadedReportCount) {
+            $errors[] = "Please select a file type for each uploaded report.";
+        } else {
+            for ($i = 0; $i < $uploadedReportCount; $i++) {
+                if (($_FILES['reports']['error'][$i] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_OK && (empty($reportFileTypeIds[$i]) || (int) $reportFileTypeIds[$i] <= 0)) {
+                    $errors[] = "Please select a file type for each uploaded report.";
+                    break;
+                }
+            }
+
+            if (empty($errors)) {
+                $selectedTypeIds = array_values(array_unique(array_filter(array_map('intval', array_slice($reportFileTypeIds, 0, $uploadedReportCount)))));
+                if (!empty($selectedTypeIds)) {
+                    $placeholders = implode(', ', array_fill(0, count($selectedTypeIds), '?'));
+                    $stmtTypes = $this->pdo->prepare("SELECT id FROM patient_report_file_types WHERE id IN ($placeholders)");
+                    $stmtTypes->execute($selectedTypeIds);
+                    $validTypeIds = array_map('intval', $stmtTypes->fetchAll(PDO::FETCH_COLUMN));
+
+                    foreach ($selectedTypeIds as $typeId) {
+                        if (!in_array($typeId, $validTypeIds, true)) {
+                            $errors[] = "Please select a valid file type for each uploaded report.";
+                            break;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     $referralSource = $data['referral_source'] ?? '';
@@ -107,8 +139,13 @@ class PatientController {
                     $original = $_FILES['reports']['name'][$i];
                     $safeName = time() . '_' . preg_replace('/[^A-Za-z0-9.\-_]/', '_', $original);
                     move_uploaded_file($_FILES['reports']['tmp_name'][$i], $uploadDir . $safeName);
-                    $stmtFile = $this->pdo->prepare("INSERT INTO file_master (patient_id, file_name, upload_date) VALUES (:pid, :fname, NOW())");
-                    $stmtFile->execute([':pid' => $patientId, ':fname' => $safeName]);
+                    $fileTypeId = !empty($data['report_file_type_ids'][$i]) ? (int) $data['report_file_type_ids'][$i] : null;
+                    $stmtFile = $this->pdo->prepare("INSERT INTO file_master (patient_id, file_name, file_type_id, upload_date) VALUES (:pid, :fname, :file_type_id, NOW())");
+                    $stmtFile->execute([
+                        ':pid' => $patientId,
+                        ':fname' => $safeName,
+                        ':file_type_id' => $fileTypeId,
+                    ]);
                 }
             }
         }
@@ -131,8 +168,19 @@ class PatientController {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public function getPatientReportFileTypes() {
+        $stmt = $this->pdo->query("SELECT id, name FROM patient_report_file_types ORDER BY name ASC");
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
     public function getPatientFiles($patientId) {
-        $stmt = $this->pdo->prepare("SELECT file_id, file_name, upload_date FROM file_master WHERE patient_id = ? ORDER BY upload_date DESC");
+        $stmt = $this->pdo->prepare(
+            "SELECT fm.file_id, fm.file_name, fm.file_type_id, prft.name AS file_type_name, fm.upload_date
+             FROM file_master fm
+             LEFT JOIN patient_report_file_types prft ON prft.id = fm.file_type_id
+             WHERE fm.patient_id = ?
+             ORDER BY fm.upload_date DESC"
+        );
         $stmt->execute([$patientId]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }

--- a/views/admin/patient_form.php
+++ b/views/admin/patient_form.php
@@ -32,6 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $referrals = $controller->getReferralSources();
+$fileTypes = $controller->getPatientReportFileTypes();
 include '../../includes/header.php';
 ?>
 

--- a/views/doctor/patient_form.php
+++ b/views/doctor/patient_form.php
@@ -32,6 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $referrals = $controller->getReferralSources();
+$fileTypes = $controller->getPatientReportFileTypes();
 include '../../includes/header.php';
 ?>
 <div class="workspace-layout">

--- a/views/receptionist/patient_form.php
+++ b/views/receptionist/patient_form.php
@@ -31,6 +31,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $referrals = $controller->getReferralSources();
+$fileTypes = $controller->getPatientReportFileTypes();
 include '../../includes/header.php';
 ?>
 <div class="workspace-layout">

--- a/views/shared/manage_patients_files.php
+++ b/views/shared/manage_patients_files.php
@@ -67,6 +67,7 @@ include '../../includes/header.php';
           <thead class="table-light">
             <tr>
               <th scope="col">File Name</th>
+              <th scope="col">File Type</th>
               <th scope="col">Uploaded On</th>
               <th scope="col">Download</th>
             </tr>
@@ -76,6 +77,7 @@ include '../../includes/header.php';
               <?php foreach ($files as $file): ?>
                 <tr>
                   <td><?= htmlspecialchars($file['file_name']) ?></td>
+                  <td><?= htmlspecialchars($file['file_type_name'] ?? '—') ?></td>
                   <td><?= date('d M Y', strtotime($file['upload_date'])) ?></td>
                   <td>
                     <a href="<?= BASE_URL ?>/views/shared/download_file.php?patient_id=<?= $patientId ?>&file=<?= urlencode($file['file_name']) ?>" class="btn btn-sm btn-outline-primary">Download</a>
@@ -84,7 +86,7 @@ include '../../includes/header.php';
               <?php endforeach; ?>
             <?php else: ?>
               <tr>
-                <td colspan="3" class="text-center text-muted py-4">No files uploaded for this patient.</td>
+                <td colspan="4" class="text-center text-muted py-4">No files uploaded for this patient.</td>
               </tr>
             <?php endif; ?>
           </tbody>

--- a/views/shared/patient_form_content.php
+++ b/views/shared/patient_form_content.php
@@ -125,6 +125,18 @@
     <div class="row g-3">
       <div class="col-md-12"><label>Reports Upload (max 5 files)</label>
         <input type="file" id="reports" name="reports[]" class="form-control" multiple>
+        <div class="form-text">After choosing files, select the file type for each file in the table below.</div>
+      </div>
+      <div class="col-md-12 d-none" id="selectedReportsContainer">
+        <table class="table table-bordered mt-3 mb-0">
+          <thead>
+            <tr>
+              <th>Selected File</th>
+              <th>File Type *</th>
+            </tr>
+          </thead>
+          <tbody id="selectedReportsBody"></tbody>
+        </table>
       </div>
       <?php if (!empty($files)): ?>
       <div class="col-md-12">
@@ -132,6 +144,7 @@
           <thead>
             <tr>
               <th>File Name</th>
+              <th>File Type</th>
               <th>Uploaded On</th>
               <th>Download</th>
             </tr>
@@ -140,6 +153,7 @@
             <?php foreach ($files as $file): ?>
             <tr>
               <td><?= htmlspecialchars($file['file_name']) ?></td>
+              <td><?= htmlspecialchars($file['file_type_name'] ?? '—') ?></td>
               <td><?= date('d M Y', strtotime($file['upload_date'])) ?></td>
               <td>
                 <a href="<?= BASE_URL ?>/views/shared/download_file.php?patient_id=<?= urlencode($patient['id']) ?>&file=<?= urlencode($file['file_name']) ?>" class="btn btn-sm btn-primary">Download</a>
@@ -169,6 +183,9 @@ const prevBtn = document.getElementById('prevBtn');
 const nextBtn = document.getElementById('nextBtn');
 const submitBtn = document.getElementById('submitBtn');
 const reportsInput = document.getElementById('reports');
+const selectedReportsContainer = document.getElementById('selectedReportsContainer');
+const selectedReportsBody = document.getElementById('selectedReportsBody');
+const reportFileTypes = <?= json_encode($fileTypes ?? [], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>;
 const referralSelect = document.querySelector('select[name="referral_source"]');
 const referralOtherFields = document.getElementById('referralOtherFields');
 const referralOtherTypeField = document.getElementById('referralOtherTypeField');
@@ -205,12 +222,57 @@ prevBtn.addEventListener('click', () => {
 
 showTab(currentTab);
 
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function renderSelectedReportRows() {
+  if (!reportsInput || !selectedReportsContainer || !selectedReportsBody) return;
+
+  selectedReportsBody.innerHTML = '';
+  if (!reportsInput.files.length) {
+    selectedReportsContainer.classList.add('d-none');
+    return;
+  }
+
+  selectedReportsContainer.classList.remove('d-none');
+  [...reportsInput.files].forEach((file) => {
+    const options = reportFileTypes.map((fileType) => {
+      return `<option value="${escapeHtml(fileType.id)}">${escapeHtml(fileType.name)}</option>`;
+    }).join('');
+
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${escapeHtml(file.name)}</td>
+      <td>
+        <select name="report_file_type_ids[]" class="form-select" required>
+          <option value="">Select file type</option>
+          ${options}
+        </select>
+      </td>
+    `;
+    selectedReportsBody.appendChild(row);
+  });
+}
+
 if (reportsInput) {
   reportsInput.addEventListener('change', function() {
     if (this.files.length > 5) {
       alert('Maximum 5 files allowed.');
       this.value = '';
     }
+
+    if (this.files.length && !reportFileTypes.length) {
+      alert('Please add patient report file types before uploading reports.');
+      this.value = '';
+    }
+
+    renderSelectedReportRows();
   });
 }
 


### PR DESCRIPTION
### Motivation
- Allow categorizing uploaded patient reports by selecting a file type from the `patient_report_file_types` master list when creating or editing a patient. 
- Ensure file types are shown in ASC order and stored with each uploaded file so the type is visible later. 
- Surface the chosen file type in patient file lists to make report metadata available in the UI.

### Description
- Added server-side validation in `saveOrUpdatePatient` to require and validate a selected file type per uploaded report and to ensure selected IDs exist in `patient_report_file_types`.
- Persist the chosen type by saving `file_type_id` into `file_master` when files are uploaded and extended `getPatientFiles` to return `file_type_name` via a `LEFT JOIN`.
- Added `getPatientReportFileTypes` to `PatientController` and loaded `fileTypes` in patient form pages (`views/admin/patient_form.php`, `views/doctor/patient_form.php`, `views/receptionist/patient_form.php`) so the Step 5 UI can render a per-file dropdown populated from `patient_report_file_types` ordered by name ASC.
- Updated the shared Step 5 form (`views/shared/patient_form_content.php`) to show a selection table for chosen files with `report_file_type_ids[]` inputs and to display stored file types in files tables, and updated `views/shared/manage_patients_files.php` to display file types in the patient files table.
- Schema changes: added `file_type_id` to `config/file_master.sql` and included a migration `config/update_file_master_add_file_type.sql` that adds the column, index, and foreign key to `patient_report_file_types` (`ON DELETE SET NULL`).

### Testing
- Ran PHP syntax checks with `php -l` on changed files: `controllers/PatientController.php`, `views/admin/patient_form.php`, `views/doctor/patient_form.php`, `views/receptionist/patient_form.php`, `views/shared/patient_form_content.php`, and `views/shared/manage_patients_files.php`, and all files reported no syntax errors.
- Verified that the new SQL migration file `config/update_file_master_add_file_type.sql` and the updated `config/file_master.sql` reflect the `file_type_id` column and foreign key constraints (manual file inspection via diff).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb311a106c8322aad104c1f7085115)