### PR TITLE
Add session file type selection, save file_type & display session files in doctor view

### DIFF
--- a/config/file_master.sql
+++ b/config/file_master.sql
@@ -3,8 +3,10 @@ CREATE TABLE file_master (
   patient_id INT NOT NULL,
   file_name VARCHAR(255) NOT NULL,
   file_type_id INT NULL,
+  treatment_session_id INT NULL,
   upload_date DATETIME NOT NULL,
   FOREIGN KEY (patient_id) REFERENCES patients(id) ON DELETE CASCADE,
-  FOREIGN KEY (file_type_id) REFERENCES patient_report_file_types(id) ON DELETE SET NULL
+  FOREIGN KEY (file_type_id) REFERENCES patient_report_file_types(id) ON DELETE SET NULL,
+  FOREIGN KEY (treatment_session_id) REFERENCES treatment_sessions(id) ON DELETE SET NULL
 );
 

--- a/config/update_file_master_add_treatment_session_id.sql
+++ b/config/update_file_master_add_treatment_session_id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE file_master
+  ADD COLUMN treatment_session_id INT NULL AFTER file_type_id,
+  ADD INDEX idx_file_master_treatment_session_id (treatment_session_id),
+  ADD CONSTRAINT fk_file_master_treatment_session
+    FOREIGN KEY (treatment_session_id) REFERENCES treatment_sessions(id)
+    ON DELETE SET NULL;

--- a/controllers/TreatmentController.php
+++ b/controllers/TreatmentController.php
@@ -144,8 +144,13 @@ class TreatmentController {
                 $original = $data['file']['name'];
                 $safeName = time() . '_' . preg_replace('/[^A-Za-z0-9.\-_]/', '_', $original);
                 move_uploaded_file($data['file']['tmp_name'], $uploadDir . $safeName);
-                $stmtFile = $this->pdo->prepare("INSERT INTO file_master (patient_id, file_name, upload_date) VALUES (:pid, :fname, NOW())");
-                $stmtFile->execute([':pid' => $data['patient_id'], ':fname' => $safeName]);
+                $stmtFile = $this->pdo->prepare("INSERT INTO file_master (patient_id, file_name, file_type_id, treatment_session_id, upload_date) VALUES (:pid, :fname, :file_type_id, :session_id, NOW())");
+                $stmtFile->execute([
+                    ':pid' => $data['patient_id'],
+                    ':fname' => $safeName,
+                    ':file_type_id' => $data['file_type_id'] ?? null,
+                    ':session_id' => $session_id,
+                ]);
             }
             /*if (!empty($data['exercises'])) {
                 foreach ($data['exercises'] as $exercise) {
@@ -306,6 +311,9 @@ class TreatmentController {
                 'notes' => $row['notes'],
             ];
         }, $machineRows);
+
+        $sessionFiles = $this->getFilesForSessionIds([$session['id']]);
+        $session['files'] = $sessionFiles[(int) $session['id']] ?? [];
 
         return $session;
     }
@@ -501,9 +509,14 @@ class TreatmentController {
                 $safeName = time() . '_' . preg_replace('/[^A-Za-z0-9.\-_]/', '_', $original);
                 move_uploaded_file($data['file']['tmp_name'], $uploadDir . $safeName);
                 $stmtFile = $this->pdo->prepare(
-                    "INSERT INTO file_master (patient_id, file_name, upload_date) VALUES (:pid, :fname, NOW())"
+                    "INSERT INTO file_master (patient_id, file_name, file_type_id, treatment_session_id, upload_date) VALUES (:pid, :fname, :file_type_id, :session_id, NOW())"
                 );
-                $stmtFile->execute([':pid' => $data['patient_id'], ':fname' => $safeName]);
+                $stmtFile->execute([
+                    ':pid' => $data['patient_id'],
+                    ':fname' => $safeName,
+                    ':file_type_id' => $data['file_type_id'] ?? null,
+                    ':session_id' => $sessionId,
+                ]);
             }
 
             $this->pdo->commit();
@@ -637,7 +650,46 @@ class TreatmentController {
             ];
         }, $machineRows);
 
+        $sessionFiles = $this->getFilesForSessionIds([$session['id']]);
+        $session['files'] = $sessionFiles[(int) $session['id']] ?? [];
+
         return $session;
+    }
+
+    private function getFilesForSessionIds(array $sessionIds) {
+        $sessionIds = array_values(array_unique(array_filter(array_map('intval', $sessionIds))));
+        if (empty($sessionIds)) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($sessionIds), '?'));
+        $stmt = $this->pdo->prepare(
+            "SELECT fm.file_id, fm.patient_id, fm.file_name, fm.file_type_id, fm.treatment_session_id, fm.upload_date, prft.name AS file_type_name"
+            . " FROM file_master fm"
+            . " LEFT JOIN patient_report_file_types prft ON prft.id = fm.file_type_id"
+            . " WHERE fm.treatment_session_id IN ($placeholders)"
+            . " ORDER BY fm.upload_date DESC, fm.file_id DESC"
+        );
+        $stmt->execute($sessionIds);
+
+        $filesBySession = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $file) {
+            $sessionId = (int) $file['treatment_session_id'];
+            if (!isset($filesBySession[$sessionId])) {
+                $filesBySession[$sessionId] = [];
+            }
+
+            $filesBySession[$sessionId][] = [
+                'file_id' => (int) $file['file_id'],
+                'patient_id' => (int) $file['patient_id'],
+                'file_name' => $file['file_name'],
+                'file_type_id' => $file['file_type_id'] !== null ? (int) $file['file_type_id'] : null,
+                'file_type_name' => $file['file_type_name'],
+                'upload_date' => $file['upload_date'],
+            ];
+        }
+
+        return $filesBySession;
     }
 
     public function getSessionsWithDetails($patient_id, $episode_id) {
@@ -731,7 +783,15 @@ class TreatmentController {
                 'amount' => null,
                 'exercises' => [],
                 'machines' => [],
+                'files' => [],
             ];
+        }
+
+        $filesBySession = $this->getFilesForSessionIds($sessionIdList);
+        foreach ($filesBySession as $sessionId => $files) {
+            if (isset($sessionMap[$sessionId])) {
+                $sessionMap[$sessionId]['files'] = $files;
+            }
         }
 
         foreach ($exerciseRows as $row) {

--- a/views/doctor/start_treatment.php
+++ b/views/doctor/start_treatment.php
@@ -38,6 +38,11 @@ $therapistStmt = $pdo->prepare("
 ");
 $therapistStmt->execute();
 $therapists = $therapistStmt->fetchAll(PDO::FETCH_ASSOC);
+$patientReportFileTypes = $patientController->getPatientReportFileTypes();
+$patientReportFileTypeMap = [];
+foreach ($patientReportFileTypes as $fileType) {
+    $patientReportFileTypeMap[(int) $fileType['id']] = $fileType['name'];
+}
 
 $therapistMap = [];
 foreach ($therapists as $therapist) {
@@ -47,6 +52,10 @@ $previousExercises = $treatmentController->getPreviousSessionExercises($patient_
 $previousMachines = $treatmentController->getPreviousSessionMachines($patient_id, $episode_id);
 $latestSessionData = $treatmentController->getLatestSessionWithDetails($patient_id, $episode_id);
 $previousSessionsWithDetails = $treatmentController->getSessionsWithDetails($patient_id, $episode_id);
+$sessionFilesById = [];
+foreach ($previousSessionsWithDetails as $sessionWithDetails) {
+    $sessionFilesById[(int) $sessionWithDetails['id']] = $sessionWithDetails['files'] ?? [];
+}
 
 $groupedSessions = [];
 foreach ($previousExercises as $ex) {
@@ -63,6 +72,7 @@ foreach ($previousExercises as $ex) {
             'secondary_therapist_name' => $ex['secondary_therapist_name'] ?? null,
             'exercises' => [],
             'machines' => [],
+            'files' => $sessionFilesById[(int) $sid] ?? [],
         ];
     }
 
@@ -85,6 +95,7 @@ foreach ($previousMachines as $machine) {
             'secondary_therapist_name' => $machine['secondary_therapist_name'] ?? null,
             'exercises' => [],
             'machines' => [],
+            'files' => $sessionFilesById[(int) $sid] ?? [],
         ];
     }
 
@@ -203,6 +214,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $secondaryTherapistId = isset($_POST['secondary_therapist_id']) && $_POST['secondary_therapist_id'] !== ''
             ? (int) $_POST['secondary_therapist_id']
             : null;
+        $uploadedSessionFile = $_FILES['session_file'] ?? null;
+        $hasSessionFileUpload = $uploadedSessionFile && ($uploadedSessionFile['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_OK;
+        $sessionFileTypeId = isset($_POST['session_file_type_id']) && $_POST['session_file_type_id'] !== ''
+            ? (int) $_POST['session_file_type_id']
+            : null;
 
         if ($primaryTherapistId <= 0 || !isset($therapistMap[$primaryTherapistId])) {
             $msg = 'Please select a valid primary therapist.';
@@ -210,6 +226,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $msg = 'Please select a valid secondary therapist.';
         } elseif ($secondaryTherapistId !== null && $secondaryTherapistId === $primaryTherapistId) {
             $msg = 'Primary and secondary therapist cannot be the same.';
+        } elseif ($hasSessionFileUpload && ($sessionFileTypeId === null || !isset($patientReportFileTypeMap[$sessionFileTypeId]))) {
+            $msg = 'Please select a valid file type for the uploaded file.';
         } else {
             $additionalNotes = trim($_POST['additional_treatment_notes'] ?? '');
 
@@ -241,7 +259,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 'additional_treatment_notes' => $additionalNotes,
                 'exercises' => $exercises_data,
                 'machines' => $machines_data,
-                'file' => $_FILES['session_file'] ?? null,
+                'file' => $uploadedSessionFile,
+                'file_type_id' => $hasSessionFileUpload ? $sessionFileTypeId : null,
             ];
 
             // Doctors cannot alter session amount; force zero for all submissions.
@@ -377,6 +396,7 @@ $adviseValue = $_POST['advise']
     ?? ($isEditingSession ? ($editingSessionData['advise'] ?? '') : '');
 $additionalTreatmentNotesValue = $_POST['additional_treatment_notes']
     ?? ($isEditingSession ? ($editingSessionData['additional_treatment_notes'] ?? '') : '');
+$selectedFileTypeId = isset($_POST['session_file_type_id']) ? (string) $_POST['session_file_type_id'] : '';
 $selectedCopySessionId = isset($_POST['copy_session_date']) ? (string) $_POST['copy_session_date'] : '';
 
 $availableSessionIds = array_map(static function ($session) {
@@ -568,6 +588,32 @@ include '../../includes/header.php';
                                               </table>
                                             </div>
                                           <?php endif; ?>
+                                          <?php if (!empty($session['files'])): ?>
+                                            <div class="table-responsive mt-3">
+                                              <table class="table table-sm table-hover align-middle mb-0">
+                                                <thead class="table-light">
+                                                  <tr>
+                                                    <th scope="col">File Name</th>
+                                                    <th scope="col">File Type</th>
+                                                    <th scope="col">Uploaded On</th>
+                                                    <th scope="col">Download</th>
+                                                  </tr>
+                                                </thead>
+                                                <tbody>
+                                                  <?php foreach ($session['files'] as $file): ?>
+                                                    <tr>
+                                                      <td><?= htmlspecialchars($file['file_name']) ?></td>
+                                                      <td><?= htmlspecialchars($file['file_type_name'] ?? '—') ?></td>
+                                                      <td><?= htmlspecialchars(date('d M Y', strtotime($file['upload_date']))) ?></td>
+                                                      <td>
+                                                        <a href="<?= BASE_URL ?>/views/shared/download_file.php?patient_id=<?= (int) $patient_id ?>&file=<?= urlencode($file['file_name']) ?>" class="btn btn-sm btn-outline-primary">Download</a>
+                                                      </td>
+                                                    </tr>
+                                                  <?php endforeach; ?>
+                                                </tbody>
+                                              </table>
+                                            </div>
+                                          <?php endif; ?>
                                         </div>
                                       <?php endforeach; ?>
                                     </div>
@@ -639,16 +685,28 @@ include '../../includes/header.php';
         <?php endif; ?>
 
         <div class="row g-3">
-          <div class="col-12 col-md-4">
+          <div class="col-12 col-md-3">
             <label class="form-label" for="session_date">Session Date</label>
             <input type="date" name="session_date" id="session_date" class="form-control" value="<?= htmlspecialchars($sessionDateValue) ?>" required>
           </div>
-          <div class="col-12 col-md-4">
+          <div class="col-12 col-md-3">
             <label class="form-label" for="session_amount">Session Amount</label>
             <input type="number" step="0.01" min="0" name="session_amount" id="session_amount" class="form-control" value="<?= htmlspecialchars($sessionAmountValue) ?>" readonly required>
             <div class="form-text">Amount entry is disabled for doctors and will be recorded as 0.</div>
           </div>
-          <div class="col-12 col-md-4">
+          <div class="col-12 col-md-3">
+            <label class="form-label" for="session_file_type_id">File Type</label>
+            <select name="session_file_type_id" id="session_file_type_id" class="form-select">
+              <option value="">Select file type</option>
+              <?php foreach ($patientReportFileTypes as $fileType): ?>
+                <option value="<?= (int) $fileType['id'] ?>" <?= ((string) $fileType['id'] === $selectedFileTypeId) ? 'selected' : '' ?>>
+                  <?= htmlspecialchars($fileType['name']) ?>
+                </option>
+              <?php endforeach; ?>
+            </select>
+            <div class="form-text">Required when uploading a file.</div>
+          </div>
+          <div class="col-12 col-md-3">
             <label class="form-label" for="session_file">Upload File (optional)</label>
             <input type="file" name="session_file" id="session_file" class="form-control">
           </div>
@@ -739,6 +797,8 @@ include '../../includes/header.php';
   const copyLastSessionInputs = document.querySelectorAll('input[name="copy_last_session"]');
   const copySessionSelect = document.getElementById('copy_session_select');
   const copySessionDateWrapper = document.getElementById('copy_session_date_wrapper');
+  const sessionFileInput = document.getElementById('session_file');
+  const sessionFileTypeSelect = document.getElementById('session_file_type_id');
 
   document.addEventListener('DOMContentLoaded', () => {
     lockSessionAmount();
@@ -753,7 +813,21 @@ include '../../includes/header.php';
       setupCopyLastSession();
     }
     setupDeleteSessionForms();
+    setupSessionFileTypeRequirement();
   });
+
+  function setupSessionFileTypeRequirement() {
+    if (!sessionFileInput || !sessionFileTypeSelect) {
+      return;
+    }
+
+    const syncFileTypeRequired = () => {
+      sessionFileTypeSelect.required = sessionFileInput.files.length > 0;
+    };
+
+    sessionFileInput.addEventListener('change', syncFileTypeRequired);
+    syncFileTypeRequired();
+  }
 
   if (primaryTherapistSelect && secondaryTherapistSelect) {
     primaryTherapistSelect.addEventListener('change', syncTherapistSelections);


### PR DESCRIPTION
### Motivation
- Doctors can upload an optional file when logging a treatment session, but file type metadata and session association were not captured or shown with previous sessions.
- The change ensures uploaded session files record a file type from `patient_report_file_types` (sorted by name ASC) and that those files are displayed alongside past sessions.

### Description
- Load `patient_report_file_types` via `PatientController::getPatientReportFileTypes()` and add a same-row `File Type` select to the doctor session form populated in ascending `name` order. (`views/doctor/start_treatment.php`).
- Validate server-side that when a session file is uploaded a valid `session_file_type_id` is provided and include `file_type_id` in the payload sent to the controller. (`views/doctor/start_treatment.php`).
- Persist uploaded session files with `file_type_id` and link them to the treatment session by adding `treatment_session_id` to `file_master`, and update `TreatmentController` to insert the new columns on save/update and return session files in session detail results. (`controllers/TreatmentController.php`, `config/file_master.sql`, `config/update_file_master_add_treatment_session_id.sql`).
- Display related session files in the previous-sessions UI as a table (file name, file type, uploaded date, download link) and add a small client-side helper that requires the file type select when a file is chosen. (`views/doctor/start_treatment.php`).

### Testing
- Ran `php -l views/doctor/start_treatment.php` and `php -l controllers/TreatmentController.php` with no syntax errors (success).
- Ran `find controllers views config -name '*.php' -print0 | xargs -0 -n1 php -l` to lint all view/controller files (success).
- Ran `git diff --check` to ensure no leftover whitespace/error markers (success).
- Verified the new migration SQL is added as `config/update_file_master_add_treatment_session_id.sql` and `config/file_master.sql` updated to include `treatment_session_id` (reviewed changes successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3a750ab083228ce9a9cb48198eb6)