### PR TITLE
Add Admin Medical Report page with controller and sidebar link

### DIFF
--- a/controllers/MedicalReportController.php
+++ b/controllers/MedicalReportController.php
@@ -1,0 +1,76 @@
+<?php
+class MedicalReportController {
+    private $pdo;
+
+    public function __construct($pdo) {
+        $this->pdo = $pdo;
+    }
+
+    public function getPatients(): array {
+        $stmt = $this->pdo->query(
+            "SELECT id, first_name, last_name, contact_number
+             FROM patients
+             ORDER BY first_name ASC, last_name ASC, id ASC"
+        );
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getPatientById(int $patientId): ?array {
+        $stmt = $this->pdo->prepare(
+            "SELECT id, first_name, last_name, contact_number
+             FROM patients
+             WHERE id = ?"
+        );
+        $stmt->execute([$patientId]);
+        $patient = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $patient ?: null;
+    }
+
+    public function getTreatmentSummary(int $patientId, string $startDate, string $endDate): array {
+        $sql = "
+            SELECT
+                session_totals.treatment_date,
+                session_totals.exercise_count,
+                session_totals.machine_count,
+                COALESCE(fee_totals.total_fees, 0) AS total_fees
+            FROM (
+                SELECT
+                    ts.session_date AS treatment_date,
+                    COUNT(DISTINCT te.id) AS exercise_count,
+                    COUNT(DISTINCT tm.id) AS machine_count
+                FROM treatment_sessions ts
+                LEFT JOIN treatment_exercises te ON te.session_id = ts.id
+                LEFT JOIN treatment_machines tm ON tm.session_id = ts.id
+                WHERE ts.patient_id = ?
+                  AND ts.session_date BETWEEN ? AND ?
+                GROUP BY ts.session_date
+            ) session_totals
+            LEFT JOIN (
+                SELECT
+                    transaction_date,
+                    SUM(amount) AS total_fees
+                FROM patient_payment_ledger
+                WHERE patient_id = ?
+                  AND transaction_type = 'charge'
+                  AND transaction_date BETWEEN ? AND ?
+                GROUP BY transaction_date
+            ) fee_totals ON fee_totals.transaction_date = session_totals.treatment_date
+            ORDER BY session_totals.treatment_date ASC
+        ";
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([$patientId, $startDate, $endDate, $patientId, $startDate, $endDate]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(static function (array $row): array {
+            return [
+                'treatment_date' => $row['treatment_date'],
+                'exercise_count' => (int) ($row['exercise_count'] ?? 0),
+                'machine_count' => (int) ($row['machine_count'] ?? 0),
+                'total_fees' => (float) ($row['total_fees'] ?? 0),
+            ];
+        }, $rows);
+    }
+}

--- a/layouts/admin_sidebar.php
+++ b/layouts/admin_sidebar.php
@@ -47,6 +47,11 @@ $adminNavItems = [
         'matches' => ['financial_reports.php'],
     ],
     [
+        'label' => 'Medical Report',
+        'href' => BASE_URL . '/views/admin/medical_report.php',
+        'matches' => ['medical_report.php'],
+    ],
+    [
         'label' => 'Logout',
         'href' => BASE_URL . '/views/shared/logout.php',
         'matches' => [],

--- a/views/admin/medical_report.php
+++ b/views/admin/medical_report.php
@@ -1,0 +1,267 @@
+<?php
+require_once '../../includes/db.php';
+require_once '../../includes/auth.php';
+requireLogin();
+requireRole('Admin');
+
+require_once '../../controllers/MedicalReportController.php';
+
+$controller = new MedicalReportController($pdo);
+$patients = $controller->getPatients();
+
+$today = new DateTimeImmutable('today');
+$defaultStart = $today->sub(new DateInterval('P6D'));
+
+$patientId = (int) ($_GET['patient_id'] ?? 0);
+$startInput = $_GET['start_date'] ?? $defaultStart->format('Y-m-d');
+$endInput = $_GET['end_date'] ?? $today->format('Y-m-d');
+$notes = $_GET['notes'] ?? '';
+$reportGenerated = ($_GET['generate'] ?? '') === '1';
+$errors = [];
+
+$startDateObj = DateTimeImmutable::createFromFormat('Y-m-d', $startInput) ?: $defaultStart;
+$endDateObj = DateTimeImmutable::createFromFormat('Y-m-d', $endInput) ?: $today;
+
+if ($startDateObj > $endDateObj) {
+    [$startDateObj, $endDateObj] = [$endDateObj, $startDateObj];
+}
+
+$startDate = $startDateObj->format('Y-m-d');
+$endDate = $endDateObj->format('Y-m-d');
+$selectedPatient = null;
+$reportRows = [];
+
+if ($reportGenerated) {
+    if ($patientId <= 0) {
+        $errors[] = 'Please select a patient.';
+    } else {
+        $selectedPatient = $controller->getPatientById($patientId);
+        if (!$selectedPatient) {
+            $errors[] = 'Selected patient could not be found.';
+        }
+    }
+
+    if (empty($errors) && $selectedPatient) {
+        $reportRows = $controller->getTreatmentSummary($patientId, $startDate, $endDate);
+    }
+}
+
+$selectedPatientName = $selectedPatient
+    ? trim(($selectedPatient['first_name'] ?? '') . ' ' . ($selectedPatient['last_name'] ?? ''))
+    : '';
+$displayStart = $startDateObj->format('j M Y');
+$displayEnd = $endDateObj->format('j M Y');
+$printDate = (new DateTimeImmutable('now'))->format('j M Y');
+$logoUrl = BASE_URL . '/assets/img/logo.jpg';
+
+include '../../includes/header.php';
+?>
+
+<div class="admin-layout medical-report-page">
+    <?php include '../../layouts/admin_sidebar.php'; ?>
+    <div class="admin-content">
+        <div class="admin-page-header no-print">
+            <div>
+                <h1 class="admin-page-title">Medical Report</h1>
+                <p class="admin-page-subtitle">Generate a printable treatment summary for any patient and date range.</p>
+            </div>
+        </div>
+
+        <?php if (!empty($errors)): ?>
+            <div class="alert alert-danger no-print" role="alert">
+                <?= htmlspecialchars(implode(' ', $errors)) ?>
+            </div>
+        <?php endif; ?>
+
+        <div class="app-card no-print">
+            <form method="get" class="row g-3 align-items-end mb-0">
+                <input type="hidden" name="generate" value="1">
+                <div class="col-12 col-lg-4">
+                    <label for="patient_id" class="form-label">Patient</label>
+                    <select class="form-select searchable-patient-select" id="patient_id" name="patient_id" required>
+                        <option value="">Search and select patient</option>
+                        <?php foreach ($patients as $patient): ?>
+                            <?php
+                                $fullName = trim(($patient['first_name'] ?? '') . ' ' . ($patient['last_name'] ?? ''));
+                                $label = $fullName;
+                                if (!empty($patient['contact_number'])) {
+                                    $label .= ' - ' . $patient['contact_number'];
+                                }
+                            ?>
+                            <option value="<?= (int) $patient['id'] ?>" <?= $patientId === (int) $patient['id'] ? 'selected' : '' ?>>
+                                <?= htmlspecialchars($label) ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                    <label for="start_date" class="form-label">Start Date</label>
+                    <input type="date" class="form-control" id="start_date" name="start_date" value="<?= htmlspecialchars($startDate) ?>" required>
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
+                    <label for="end_date" class="form-label">End Date</label>
+                    <input type="date" class="form-control" id="end_date" name="end_date" value="<?= htmlspecialchars($endDate) ?>" required>
+                </div>
+                <div class="col-12 col-lg-2">
+                    <button class="btn btn-primary w-100">Generate</button>
+                </div>
+                <div class="col-12">
+                    <label for="notes" class="form-label">Notes</label>
+                    <textarea class="form-control" id="notes" name="notes" rows="4" placeholder="Enter additional notes to show on the printed report."><?= htmlspecialchars($notes) ?></textarea>
+                </div>
+            </form>
+        </div>
+
+        <?php if ($reportGenerated && empty($errors)): ?>
+            <div class="app-card no-print">
+                <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-3">
+                    <div>
+                        <h5 class="mb-1">Report Preview</h5>
+                        <p class="text-muted mb-0">
+                            <?= htmlspecialchars($selectedPatientName) ?> &middot;
+                            <?= htmlspecialchars($displayStart) ?> to <?= htmlspecialchars($displayEnd) ?>
+                        </p>
+                    </div>
+                    <button type="button" class="btn btn-outline-primary align-self-md-start" onclick="window.print()" <?= empty($reportRows) ? 'disabled' : '' ?>>Print</button>
+                </div>
+
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle mb-0">
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Exercises</th>
+                                <th>Machines</th>
+                                <th>Fees</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php if (!empty($reportRows)): ?>
+                                <?php foreach ($reportRows as $row): ?>
+                                    <tr>
+                                        <td><?= htmlspecialchars(date('j M Y', strtotime($row['treatment_date']))) ?></td>
+                                        <td><?= (int) $row['exercise_count'] ?> <?= (int) $row['exercise_count'] === 1 ? 'Exercise' : 'Exercises' ?></td>
+                                        <td><?= (int) $row['machine_count'] ?> <?= (int) $row['machine_count'] === 1 ? 'Machine' : 'Machines' ?></td>
+                                        <td><?= number_format((float) $row['total_fees'], 2) ?></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php else: ?>
+                                <tr>
+                                    <td colspan="4" class="text-center text-muted">No treatment sessions found for the selected date range.</td>
+                                </tr>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<?php if ($reportGenerated && empty($errors) && !empty($reportRows)): ?>
+    <section class="medical-report-print print-only" aria-label="Printable medical report">
+        <div class="text-center mb-4">
+            <img src="<?= htmlspecialchars($logoUrl) ?>" alt="Clinic Logo" class="medical-report-logo">
+        </div>
+
+        <p><strong>Print Date:</strong> <?= htmlspecialchars($printDate) ?></p>
+        <p><strong>Subject:</strong> To Whomever It May Concern</p>
+        <p>
+            This is to certify that <?= htmlspecialchars($selectedPatientName) ?> received treatment from
+            <?= htmlspecialchars($displayStart) ?> to <?= htmlspecialchars($displayEnd) ?> at our clinic with the following details:
+        </p>
+
+        <table class="table table-bordered align-middle medical-report-print-table">
+            <thead>
+                <tr>
+                    <th>Date</th>
+                    <th>Exercises</th>
+                    <th>Machines</th>
+                    <th>Fees</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($reportRows as $row): ?>
+                    <tr>
+                        <td><?= htmlspecialchars(date('j M Y', strtotime($row['treatment_date']))) ?></td>
+                        <td><?= (int) $row['exercise_count'] ?> <?= (int) $row['exercise_count'] === 1 ? 'Exercise' : 'Exercises' ?></td>
+                        <td><?= (int) $row['machine_count'] ?> <?= (int) $row['machine_count'] === 1 ? 'Machine' : 'Machines' ?></td>
+                        <td><?= number_format((float) $row['total_fees'], 2) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+
+        <div class="mt-4">
+            <strong>Additional Notes</strong>
+            <p id="printNotes" class="medical-report-notes"><?= nl2br(htmlspecialchars($notes !== '' ? $notes : 'None')) ?></p>
+        </div>
+    </section>
+<?php endif; ?>
+
+<style>
+.medical-report-logo {
+    max-height: 110px;
+    max-width: 260px;
+}
+
+.print-only {
+    display: none;
+}
+
+@media print {
+    body {
+        background: #fff !important;
+    }
+
+    body > nav,
+    .toast-container,
+    .no-print {
+        display: none !important;
+    }
+
+    .app-main {
+        max-width: none !important;
+        padding: 0 !important;
+    }
+
+    .medical-report-print {
+        display: block !important;
+        color: #000;
+        font-size: 12pt;
+        padding: 0.25in;
+    }
+
+    .medical-report-print-table th,
+    .medical-report-print-table td {
+        border: 1px solid #000 !important;
+        padding: 0.4rem !important;
+    }
+
+    .medical-report-notes {
+        white-space: pre-wrap;
+    }
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    if (window.jQuery && jQuery.fn.select2) {
+        jQuery('.searchable-patient-select').select2({
+            placeholder: 'Search and select patient',
+            width: '100%'
+        });
+    }
+
+    const notes = document.getElementById('notes');
+    const printNotes = document.getElementById('printNotes');
+
+    if (notes && printNotes) {
+        notes.addEventListener('input', function () {
+            printNotes.textContent = notes.value.trim() || 'None';
+        });
+    }
+});
+</script>
+
+<?php include '../../includes/footer.php'; ?>


### PR DESCRIPTION
### Motivation

- Provide admins with a simple way to generate a printable treatment summary/certificate for a patient over a date range. 
- Include exercises, machines and fee totals per date and allow adding notes for the printed certificate.

### Description

- Added `controllers/MedicalReportController.php` with `getPatients()`, `getPatientById()` and `getTreatmentSummary()` to fetch patients and aggregate per-date exercise/machine counts and fees.
- Added admin view `views/admin/medical_report.php` that provides a searchable patient dropdown (Select2), start/end date inputs, `Generate` button, notes textarea, a preview table and a print-only certificate layout containing clinic logo, print date, subject line, the aggregated table and additional notes.
- Added a new navigation item `Medical Report` to the admin sidebar in `layouts/admin_sidebar.php` to surface the page under the Admin panel.
- Included print CSS and a small client-side script to initialize Select2 and keep the printed notes synchronized with the textarea.

### Testing

- Ran PHP lint on the new controller with `php -l controllers/MedicalReportController.php` and it reported no syntax errors (success).
- Ran PHP lint on the new view with `php -l views/admin/medical_report.php` and it reported no syntax errors (success).
- Ran PHP lint on the modified sidebar with `php -l layouts/admin_sidebar.php` and it reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01974e29e083228b32f66e006a5903)