### PR TITLE
Add Machine Library to doctor sidebar and dashboard

### DIFF
--- a/layouts/doctor_sidebar.php
+++ b/layouts/doctor_sidebar.php
@@ -32,6 +32,11 @@ $doctorNavItems = [
         'matches' => ['exercises_list.php'],
     ],
     [
+        'label' => 'Machine Library',
+        'href' => BASE_URL . '/views/doctor/machines_list.php',
+        'matches' => ['machines_list.php'],
+    ],
+    [
         'label' => 'Logout',
         'href' => BASE_URL . '/views/shared/logout.php',
         'matches' => [],

--- a/views/dashboard/doctor_dashboard.php
+++ b/views/dashboard/doctor_dashboard.php
@@ -9,6 +9,7 @@ requireRole('Doctor');
 $totalPatients = $pdo->query("SELECT COUNT(*) FROM patients")->fetchColumn();
 $activePatients = $pdo->query("SELECT COUNT(DISTINCT patient_id) FROM treatment_episodes WHERE status = 'Active'")->fetchColumn();
 $totalExercises = $pdo->query("SELECT COUNT(*) FROM exercises_master")->fetchColumn();
+$totalMachines = $pdo->query("SELECT COUNT(*) FROM machines")->fetchColumn();
 
 include '../../includes/header.php';
 ?>
@@ -23,25 +24,32 @@ include '../../includes/header.php';
     </div>
 
     <div class="row g-3 g-lg-4">
-      <div class="col-12 col-sm-6 col-xl-4">
+      <div class="col-12 col-sm-6 col-xl-3">
         <div class="stat-card bg-primary text-white h-100">
           <div class="text-uppercase small text-white-50 fw-semibold">Total Patients</div>
           <div class="display-6 my-2"><?= number_format((int) $totalPatients) ?></div>
           <a href="<?= BASE_URL ?>/views/doctor/manage_patients.php" class="btn btn-light btn-sm mt-2">View Patients</a>
         </div>
       </div>
-      <div class="col-12 col-sm-6 col-xl-4">
+      <div class="col-12 col-sm-6 col-xl-3">
         <div class="stat-card bg-success text-white h-100">
           <div class="text-uppercase small text-white-50 fw-semibold">Active Patients</div>
           <div class="display-6 my-2"><?= number_format((int) $activePatients) ?></div>
           <a href="<?= BASE_URL ?>/views/doctor/active_patients.php" class="btn btn-light btn-sm mt-2">View Active</a>
         </div>
       </div>
-      <div class="col-12 col-sm-6 col-xl-4">
+      <div class="col-12 col-sm-6 col-xl-3">
         <div class="stat-card bg-info text-white h-100">
           <div class="text-uppercase small text-white-50 fw-semibold">Total Exercises</div>
           <div class="display-6 my-2"><?= number_format((int) $totalExercises) ?></div>
           <a href="<?= BASE_URL ?>/views/doctor/exercises_list.php" class="btn btn-light btn-sm mt-2">View Exercises</a>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6 col-xl-3">
+        <div class="stat-card bg-warning text-dark h-100">
+          <div class="text-uppercase small text-black-50 fw-semibold">Total Machines</div>
+          <div class="display-6 my-2"><?= number_format((int) $totalMachines) ?></div>
+          <a href="<?= BASE_URL ?>/views/doctor/machines_list.php" class="btn btn-light btn-sm mt-2">View Machines</a>
         </div>
       </div>
     </div>

--- a/views/doctor/machines_list.php
+++ b/views/doctor/machines_list.php
@@ -1,0 +1,47 @@
+<?php
+require_once '../../includes/db.php';
+require_once '../../includes/auth.php';
+requireLogin();
+requireRole('Doctor');
+
+$machines = $pdo->query("SELECT name, default_duration_minutes FROM machines ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
+
+include '../../includes/header.php';
+?>
+<div class="workspace-layout">
+  <?php include '../../layouts/doctor_sidebar.php'; ?>
+  <div class="workspace-content">
+    <div class="workspace-page-header">
+      <div>
+        <h1 class="workspace-page-title">Machine Library</h1>
+        <p class="workspace-page-subtitle">Reference the standard therapy machines available to use in treatment sessions.</p>
+      </div>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead class="table-light">
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Default Duration (min)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php if (!empty($machines)): ?>
+            <?php foreach ($machines as $machine): ?>
+              <tr>
+                <td><?= htmlspecialchars($machine['name']) ?></td>
+                <td><?= htmlspecialchars((string) $machine['default_duration_minutes']) ?></td>
+              </tr>
+            <?php endforeach; ?>
+          <?php else: ?>
+            <tr>
+              <td colspan="2" class="text-center text-muted py-4">No machines configured in the master list yet.</td>
+            </tr>
+          <?php endif; ?>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+<?php include '../../includes/footer.php'; ?>


### PR DESCRIPTION
### Motivation
- Provide doctors with a dedicated Machine Library that mirrors the existing Exercises Library for quick reference of master machines. 
- Surface the total number of machines on the Doctor Dashboard so doctors can navigate directly to the machine list. 
- Keep the doctor UI consistent with existing admin/doctor listing patterns for master data.

### Description
- Added a new navigation item `Machine Library` to the doctor menu in `layouts/doctor_sidebar.php` linking to `views/doctor/machines_list.php` and marking `machines_list.php` as a match. 
- Added a machine count query (`$totalMachines = $pdo->query("SELECT COUNT(*) FROM machines")->fetchColumn();`) and a new dashboard stat card linking to `views/doctor/machines_list.php` in `views/dashboard/doctor_dashboard.php`, and adjusted column widths to fit four cards. 
- Created a new `views/doctor/machines_list.php` page that queries `machines` and displays `name` and `default_duration_minutes` using the same table layout pattern as `exercises_list.php`. 
- Minor styling: a `bg-warning` stat card with readable text class was used to match existing card styles.

### Testing
- Ran `php -l layouts/doctor_sidebar.php` and it returned `No syntax errors detected`.
- Ran `php -l views/dashboard/doctor_dashboard.php` and `php -l views/doctor/machines_list.php` and both returned `No syntax errors detected`.
- Ran `git diff --check` and there were no whitespace or diff-check issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a500b5dc8322bdf2e26e0cb794fe)