### PR TITLE
Add reusable Exercise Groups (admin/doctor) with DB migration and duplicate-prevention

### DIFF
--- a/config/exercise_groups.sql
+++ b/config/exercise_groups.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS exercise_groups (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    created_by_user_id INT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_exercise_groups_title (title),
+    KEY idx_exercise_groups_active_title (is_active, title),
+    CONSTRAINT fk_exercise_groups_created_by
+        FOREIGN KEY (created_by_user_id) REFERENCES users(id)
+        ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS exercise_group_exercises (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    group_id INT NOT NULL,
+    exercise_id INT NOT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_group_exercise (group_id, exercise_id),
+    KEY idx_group_exercises_exercise_id (exercise_id),
+    CONSTRAINT fk_group_exercises_group
+        FOREIGN KEY (group_id) REFERENCES exercise_groups(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_group_exercises_exercise
+        FOREIGN KEY (exercise_id) REFERENCES exercises_master(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS exercise_group_machines (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    group_id INT NOT NULL,
+    machine_id INT NOT NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_group_machine (group_id, machine_id),
+    KEY idx_group_machines_machine_id (machine_id),
+    CONSTRAINT fk_group_machines_group
+        FOREIGN KEY (group_id) REFERENCES exercise_groups(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_group_machines_machine
+        FOREIGN KEY (machine_id) REFERENCES machines(id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/controllers/ExerciseGroupController.php
+++ b/controllers/ExerciseGroupController.php
@@ -1,0 +1,200 @@
+<?php
+
+class ExerciseGroupController {
+    private $pdo;
+
+    public function __construct($pdo) {
+        $this->pdo = $pdo;
+    }
+
+    public function handleActions($createdByUserId = null) {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') return '';
+
+        $action = $_POST['action'] ?? '';
+        $id = isset($_POST['id']) ? (int) $_POST['id'] : 0;
+
+        if ($action === 'add_group' || ($action === 'edit_group' && $id > 0)) {
+            $title = trim($_POST['title'] ?? '');
+            $isActive = isset($_POST['is_active']) ? (int) $_POST['is_active'] : 1;
+            $exerciseIds = $_POST['exercise_ids'] ?? [];
+            $machineIds = $_POST['machine_ids'] ?? [];
+
+            if ($title === '') {
+                return 'Exercise group title is required.';
+            }
+
+            $exerciseIds = $this->uniquePositiveIds($exerciseIds);
+            $machineIds = $this->uniquePositiveIds($machineIds);
+
+            if (empty($exerciseIds) && empty($machineIds)) {
+                return 'Please select at least one exercise or machine.';
+            }
+
+            $duplicateStmt = $this->pdo->prepare(
+                'SELECT COUNT(*) FROM exercise_groups WHERE title = ? AND id != ?'
+            );
+            $duplicateStmt->execute([$title, $action === 'edit_group' ? $id : 0]);
+            if ($duplicateStmt->fetchColumn() > 0) {
+                return 'Another exercise group with this title already exists.';
+            }
+
+            try {
+                $this->pdo->beginTransaction();
+
+                if ($action === 'add_group') {
+                    $stmt = $this->pdo->prepare(
+                        'INSERT INTO exercise_groups (title, is_active, created_by_user_id) VALUES (?, ?, ?)'
+                    );
+                    $stmt->execute([$title, $isActive, $createdByUserId]);
+                    $id = (int) $this->pdo->lastInsertId();
+                    $message = 'Exercise group added successfully.';
+                } else {
+                    $stmt = $this->pdo->prepare(
+                        'UPDATE exercise_groups SET title = ?, is_active = ? WHERE id = ?'
+                    );
+                    $stmt->execute([$title, $isActive, $id]);
+                    $this->pdo->prepare('DELETE FROM exercise_group_exercises WHERE group_id = ?')->execute([$id]);
+                    $this->pdo->prepare('DELETE FROM exercise_group_machines WHERE group_id = ?')->execute([$id]);
+                    $message = 'Exercise group updated successfully.';
+                }
+
+                $this->saveGroupItems($id, $exerciseIds, $machineIds);
+                $this->pdo->commit();
+
+                return $message;
+            } catch (Exception $e) {
+                if ($this->pdo->inTransaction()) {
+                    $this->pdo->rollBack();
+                }
+                return 'Error: ' . $e->getMessage();
+            }
+        }
+
+        if ($action === 'toggle_group' && $id > 0) {
+            $stmt = $this->pdo->prepare('UPDATE exercise_groups SET is_active = NOT is_active WHERE id = ?');
+            $stmt->execute([$id]);
+            return 'Exercise group status updated.';
+        }
+
+        if ($action === 'delete_group' && $id > 0) {
+            $stmt = $this->pdo->prepare('DELETE FROM exercise_groups WHERE id = ?');
+            $stmt->execute([$id]);
+            return 'Exercise group deleted.';
+        }
+
+        return '';
+    }
+
+    public function getGroups($search = '', $page = 1, $limit = 10) {
+        $offset = ((int) $page - 1) * (int) $limit;
+        $sql = "SELECT eg.*, u.name AS created_by_name,
+                    (SELECT COUNT(*) FROM exercise_group_exercises ege WHERE ege.group_id = eg.id) AS exercise_count,
+                    (SELECT COUNT(*) FROM exercise_group_machines egm WHERE egm.group_id = eg.id) AS machine_count
+                FROM exercise_groups eg
+                LEFT JOIN users u ON u.id = eg.created_by_user_id
+                WHERE eg.title LIKE ?
+                ORDER BY eg.id DESC
+                LIMIT $limit OFFSET $offset";
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(['%' . $search . '%']);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function countGroups($search = '') {
+        $stmt = $this->pdo->prepare('SELECT COUNT(*) FROM exercise_groups WHERE title LIKE ?');
+        $stmt->execute(['%' . $search . '%']);
+        return (int) $stmt->fetchColumn();
+    }
+
+    public function getGroupDetails($groupId) {
+        $stmt = $this->pdo->prepare('SELECT * FROM exercise_groups WHERE id = ?');
+        $stmt->execute([(int) $groupId]);
+        $group = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$group) {
+            return null;
+        }
+
+        $exerciseStmt = $this->pdo->prepare(
+            'SELECT ege.exercise_id, em.name, em.default_reps, em.default_duration_minutes
+             FROM exercise_group_exercises ege
+             INNER JOIN exercises_master em ON em.id = ege.exercise_id
+             WHERE ege.group_id = ?
+             ORDER BY ege.sort_order ASC, em.name ASC'
+        );
+        $exerciseStmt->execute([(int) $groupId]);
+
+        $machineStmt = $this->pdo->prepare(
+            'SELECT egm.machine_id, m.name, m.default_duration_minutes
+             FROM exercise_group_machines egm
+             INNER JOIN machines m ON m.id = egm.machine_id
+             WHERE egm.group_id = ?
+             ORDER BY egm.sort_order ASC, m.name ASC'
+        );
+        $machineStmt->execute([(int) $groupId]);
+
+        $group['exercises'] = $exerciseStmt->fetchAll(PDO::FETCH_ASSOC);
+        $group['machines'] = $machineStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return $group;
+    }
+
+    public function getActiveGroupsWithItems() {
+        $stmt = $this->pdo->query(
+            'SELECT id, title FROM exercise_groups WHERE is_active = 1 ORDER BY title ASC'
+        );
+        $groups = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        foreach ($groups as &$group) {
+            $details = $this->getGroupDetails((int) $group['id']);
+            $group['exercises'] = $details['exercises'] ?? [];
+            $group['machines'] = $details['machines'] ?? [];
+        }
+        unset($group);
+
+        return $groups;
+    }
+
+    public function getExerciseMaster() {
+        return $this->pdo->query(
+            'SELECT id, name, default_reps, default_duration_minutes FROM exercises_master WHERE is_active = 1 ORDER BY name'
+        )->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getMachineMaster() {
+        return $this->pdo->query(
+            'SELECT id, name, default_duration_minutes FROM machines ORDER BY name'
+        )->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    private function uniquePositiveIds($ids) {
+        if (!is_array($ids)) {
+            return [];
+        }
+
+        $clean = [];
+        foreach ($ids as $id) {
+            $id = (int) $id;
+            if ($id > 0) {
+                $clean[$id] = $id;
+            }
+        }
+
+        return array_values($clean);
+    }
+
+    private function saveGroupItems($groupId, array $exerciseIds, array $machineIds) {
+        $exerciseStmt = $this->pdo->prepare(
+            'INSERT INTO exercise_group_exercises (group_id, exercise_id, sort_order) VALUES (?, ?, ?)'
+        );
+        foreach ($exerciseIds as $sortOrder => $exerciseId) {
+            $exerciseStmt->execute([$groupId, $exerciseId, $sortOrder + 1]);
+        }
+
+        $machineStmt = $this->pdo->prepare(
+            'INSERT INTO exercise_group_machines (group_id, machine_id, sort_order) VALUES (?, ?, ?)'
+        );
+        foreach ($machineIds as $sortOrder => $machineId) {
+            $machineStmt->execute([$groupId, $machineId, $sortOrder + 1]);
+        }
+    }
+}

--- a/controllers/TreatmentController.php
+++ b/controllers/TreatmentController.php
@@ -8,6 +8,7 @@ class TreatmentController {
 
     public function saveSession($data) {
         try {
+            $this->validateNoDuplicateTreatmentItems($data);
             $this->pdo->beginTransaction();
 
             // Insert treatment session
@@ -45,12 +46,13 @@ class TreatmentController {
             for ($i = 0; $i < $exerciseCount; $i++) {
                 $exerciseId = $exerciseIds[$i];
                 if ($exerciseId === 'other') {
-                    $name = $exerciseNames[$i] ?? 'Custom Exercise';
+                    $name = trim($exerciseNames[$i] ?? '');
+                    if ($name === '') {
+                        throw new InvalidArgumentException('Exercise name is required when selecting Other.');
+                    }
                     $reps = $exerciseReps[$i] ?? 0;
                     $dur = $exerciseDurations[$i] ?? 0;
-                    $stmtNew = $this->pdo->prepare("INSERT INTO exercises_master (name, default_reps, default_duration_minutes, is_active) VALUES (?, ?, ?, 1)");
-                    $stmtNew->execute([$name, $reps, $dur]);
-                    $exerciseId = $this->pdo->lastInsertId();
+                    $exerciseId = $this->findOrCreateExercise($name, $reps, $dur);
                 }
 
                 $stmtEx = $this->pdo->prepare("
@@ -341,6 +343,7 @@ class TreatmentController {
         }
 
         try {
+            $this->validateNoDuplicateTreatmentItems($data);
             $this->pdo->beginTransaction();
 
             $updateStmt = $this->pdo->prepare(
@@ -399,15 +402,12 @@ class TreatmentController {
                 }
 
                 if ($exerciseId === 'other') {
-                    $name = $customName !== '' ? $customName : 'Custom Exercise';
+                    if ($customName === '') {
+                        throw new InvalidArgumentException('Exercise name is required when selecting Other.');
+                    }
                     $reps = isset($exerciseReps[$i]) ? (int) $exerciseReps[$i] : 0;
                     $duration = isset($exerciseDurations[$i]) ? (int) $exerciseDurations[$i] : 0;
-                    $stmtNew = $this->pdo->prepare(
-                        "INSERT INTO exercises_master (name, default_reps, default_duration_minutes, is_active)"
-                        . " VALUES (?, ?, ?, 1)"
-                    );
-                    $stmtNew->execute([$name, $reps, $duration]);
-                    $exerciseId = $this->pdo->lastInsertId();
+                    $exerciseId = $this->findOrCreateExercise($customName, $reps, $duration);
                 }
 
                 if ($exerciseId === '') {
@@ -654,6 +654,77 @@ class TreatmentController {
         $session['files'] = $sessionFiles[(int) $session['id']] ?? [];
 
         return $session;
+    }
+
+
+    private function validateNoDuplicateTreatmentItems(array $data) {
+        $exerciseIds = $data['exercises']['exercise_id'] ?? [];
+        $exerciseNames = $data['exercises']['new_name'] ?? [];
+        $this->assertNoDuplicateSelections(
+            is_array($exerciseIds) ? $exerciseIds : [],
+            is_array($exerciseNames) ? $exerciseNames : [],
+            'Exercise',
+            'exercises_master'
+        );
+
+        $machineIds = $data['machines']['machine_id'] ?? [];
+        $machineNames = $data['machines']['new_name'] ?? [];
+        $this->assertNoDuplicateSelections(
+            is_array($machineIds) ? $machineIds : [],
+            is_array($machineNames) ? $machineNames : [],
+            'Machine',
+            'machines'
+        );
+    }
+
+    private function assertNoDuplicateSelections(array $ids, array $customNames, $label, $masterTable) {
+        $seen = [];
+        $findByNameStmt = $this->pdo->prepare("SELECT id FROM $masterTable WHERE name = ? LIMIT 1");
+
+        foreach ($ids as $index => $rawId) {
+            $rawId = trim((string) $rawId);
+            if ($rawId === '') {
+                continue;
+            }
+
+            if ($rawId === 'other') {
+                $customName = $this->normalizeTreatmentItemName($customNames[$index] ?? '');
+                if ($customName === '') {
+                    continue;
+                }
+                $findByNameStmt->execute([trim((string) ($customNames[$index] ?? ''))]);
+                $existingId = $findByNameStmt->fetchColumn();
+                $key = $existingId !== false ? 'id:' . (int) $existingId : 'custom:' . $customName;
+            } else {
+                $key = 'id:' . (int) $rawId;
+            }
+
+            if (isset($seen[$key])) {
+                throw new InvalidArgumentException($label . ' cannot be selected more than once in the same treatment session.');
+            }
+
+            $seen[$key] = true;
+        }
+    }
+
+    private function normalizeTreatmentItemName($name) {
+        return strtolower(trim(preg_replace('/\s+/', ' ', (string) $name)));
+    }
+
+    private function findOrCreateExercise($name, $reps, $duration) {
+        $findStmt = $this->pdo->prepare('SELECT id FROM exercises_master WHERE name = ? LIMIT 1');
+        $findStmt->execute([$name]);
+        $existing = $findStmt->fetch(PDO::FETCH_ASSOC);
+        if ($existing) {
+            return (int) $existing['id'];
+        }
+
+        $stmtNew = $this->pdo->prepare(
+            'INSERT INTO exercises_master (name, default_reps, default_duration_minutes, is_active) VALUES (?, ?, ?, 1)'
+        );
+        $stmtNew->execute([$name, $reps, $duration]);
+
+        return (int) $this->pdo->lastInsertId();
     }
 
     private function getFilesForSessionIds(array $sessionIds) {

--- a/layouts/admin_sidebar.php
+++ b/layouts/admin_sidebar.php
@@ -32,6 +32,11 @@ $adminNavItems = [
         'matches' => ['manage_machines.php'],
     ],
     [
+        'label' => 'Exercise Groups',
+        'href' => BASE_URL . '/views/admin/manage_exercise_groups.php',
+        'matches' => ['manage_exercise_groups.php'],
+    ],
+    [
         'label' => 'Patient Report File Types',
         'href' => BASE_URL . '/views/admin/manage_patient_report_file_types.php',
         'matches' => ['manage_patient_report_file_types.php'],

--- a/layouts/doctor_sidebar.php
+++ b/layouts/doctor_sidebar.php
@@ -37,6 +37,11 @@ $doctorNavItems = [
         'matches' => ['machines_list.php'],
     ],
     [
+        'label' => 'Exercise Groups',
+        'href' => BASE_URL . '/views/doctor/manage_exercise_groups.php',
+        'matches' => ['manage_exercise_groups.php'],
+    ],
+    [
         'label' => 'Logout',
         'href' => BASE_URL . '/views/shared/logout.php',
         'matches' => [],

--- a/views/admin/manage_exercise_groups.php
+++ b/views/admin/manage_exercise_groups.php
@@ -1,0 +1,40 @@
+<?php
+require_once '../../includes/db.php';
+require_once '../../includes/auth.php';
+requireLogin();
+requireRole('Admin');
+
+require_once '../../controllers/ExerciseGroupController.php';
+$groupController = new ExerciseGroupController($pdo);
+
+$msg = $groupController->handleActions($_SESSION['user_id'] ?? null);
+
+$search = $_GET['search'] ?? '';
+$page = isset($_GET['page']) ? max(1, (int) $_GET['page']) : 1;
+$limit = 10;
+
+$groups = $groupController->getGroups($search, $page, $limit);
+$total = $groupController->countGroups($search);
+$totalPages = (int) ceil($total / $limit);
+$exerciseMaster = $groupController->getExerciseMaster();
+$machineMaster = $groupController->getMachineMaster();
+$pageUrl = 'manage_exercise_groups.php';
+
+include '../../includes/header.php';
+?>
+
+<div class="admin-layout">
+    <?php include '../../layouts/admin_sidebar.php'; ?>
+    <div class="admin-content">
+        <div class="admin-page-header">
+            <div>
+                <h1 class="admin-page-title">Exercise Groups</h1>
+                <p class="admin-page-subtitle">Create reusable exercise and machine bundles for common treatment plans.</p>
+            </div>
+        </div>
+
+        <?php include __DIR__ . '/../shared/manage_exercise_groups_content.php'; ?>
+    </div>
+</div>
+
+<?php include '../../includes/footer.php'; ?>

--- a/views/doctor/manage_exercise_groups.php
+++ b/views/doctor/manage_exercise_groups.php
@@ -1,0 +1,40 @@
+<?php
+require_once '../../includes/db.php';
+require_once '../../includes/auth.php';
+requireLogin();
+requireRole('Doctor');
+
+require_once '../../controllers/ExerciseGroupController.php';
+$groupController = new ExerciseGroupController($pdo);
+
+$msg = $groupController->handleActions($_SESSION['user_id'] ?? null);
+
+$search = $_GET['search'] ?? '';
+$page = isset($_GET['page']) ? max(1, (int) $_GET['page']) : 1;
+$limit = 10;
+
+$groups = $groupController->getGroups($search, $page, $limit);
+$total = $groupController->countGroups($search);
+$totalPages = (int) ceil($total / $limit);
+$exerciseMaster = $groupController->getExerciseMaster();
+$machineMaster = $groupController->getMachineMaster();
+$pageUrl = 'manage_exercise_groups.php';
+
+include '../../includes/header.php';
+?>
+
+<div class="workspace-layout">
+    <?php include '../../layouts/doctor_sidebar.php'; ?>
+    <div class="workspace-content">
+        <div class="workspace-page-header">
+            <div>
+                <h1 class="workspace-page-title">Exercise Groups</h1>
+                <p class="workspace-page-subtitle">Create reusable exercise and machine bundles for daily treatments.</p>
+            </div>
+        </div>
+
+        <?php include __DIR__ . '/../shared/manage_exercise_groups_content.php'; ?>
+    </div>
+</div>
+
+<?php include '../../includes/footer.php'; ?>

--- a/views/doctor/start_treatment.php
+++ b/views/doctor/start_treatment.php
@@ -7,10 +7,12 @@ requireRole('Doctor');
 require_once '../../controllers/TreatmentController.php';
 require_once '../../controllers/PatientController.php';
 require_once '../../controllers/PaymentController.php';
+require_once '../../controllers/ExerciseGroupController.php';
 
 $treatmentController = new TreatmentController($pdo);
 $patientController = new PatientController($pdo);
 $paymentController = new PaymentController($pdo);
+$exerciseGroupController = new ExerciseGroupController($pdo);
 
 $patient_id = isset($_GET['patient_id']) ? (int) $_GET['patient_id'] : 0;
 $episode_id = isset($_GET['episode_id']) ? (int) $_GET['episode_id'] : 0;
@@ -38,6 +40,7 @@ $therapistStmt = $pdo->prepare("
 ");
 $therapistStmt->execute();
 $therapists = $therapistStmt->fetchAll(PDO::FETCH_ASSOC);
+$exerciseGroups = $exerciseGroupController->getActiveGroupsWithItems();
 $patientReportFileTypes = $patientController->getPatientReportFileTypes();
 $patientReportFileTypeMap = [];
 foreach ($patientReportFileTypes as $fileType) {
@@ -684,6 +687,25 @@ include '../../includes/header.php';
           </div>
         <?php endif; ?>
 
+
+        <?php if (!$isEditingSession): ?>
+          <div class="row g-3">
+            <div class="col-12 col-md-8 col-lg-6">
+              <label class="form-label" for="exercise_group_select">Apply Exercise Group</label>
+              <div class="input-group">
+                <select id="exercise_group_select" class="form-select" <?= $exerciseGroups ? '' : 'disabled' ?>>
+                  <option value="">Select group</option>
+                  <?php foreach ($exerciseGroups as $group): ?>
+                    <option value="<?= (int) $group['id'] ?>"><?= htmlspecialchars($group['title']) ?></option>
+                  <?php endforeach; ?>
+                </select>
+                <button type="button" class="btn btn-outline-primary" onclick="applySelectedExerciseGroup()" <?= $exerciseGroups ? '' : 'disabled' ?>>Apply Group</button>
+              </div>
+              <div class="form-text">Selecting a group fills the exercises and machines below. You can still edit the rows before saving.</div>
+            </div>
+          </div>
+        <?php endif; ?>
+
         <div class="row g-3">
           <div class="col-12 col-md-3">
             <label class="form-label" for="session_date">Session Date</label>
@@ -789,6 +811,7 @@ include '../../includes/header.php';
   const machineMaster = <?= json_encode($machine_master) ?>;
   const latestSessionData = <?= json_encode($latestSessionData, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
   const previousSessions = <?= json_encode($previousSessionsWithDetails, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
+  const exerciseGroups = <?= json_encode($exerciseGroups, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
   const editingSession = <?= json_encode($editingSessionData, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
   const isEditingSession = Boolean(editingSession && editingSession.id);
   const amountInput = document.getElementById('session_amount');
@@ -836,6 +859,15 @@ include '../../includes/header.php';
         secondaryTherapistSelect.value = '';
       }
       syncTherapistSelections();
+    });
+  }
+
+  const treatmentForm = document.querySelector('form[method="POST"]');
+  if (treatmentForm) {
+    treatmentForm.addEventListener('submit', function (event) {
+      if (!validateUniqueTreatmentSelections()) {
+        event.preventDefault();
+      }
     });
   }
 
@@ -1025,6 +1057,84 @@ include '../../includes/header.php';
 
   function populateFromLastSession() {
     populateFromSession(latestSessionData);
+  }
+
+
+  function applySelectedExerciseGroup() {
+    const groupSelect = document.getElementById('exercise_group_select');
+    if (!groupSelect || !groupSelect.value) {
+      showToast('Please select an exercise group first.');
+      return;
+    }
+
+    const selectedGroup = exerciseGroups.find(group => String(group.id) === String(groupSelect.value));
+    if (!selectedGroup) {
+      showToast('Selected exercise group could not be found.');
+      return;
+    }
+
+    const exercises = (selectedGroup.exercises || []).map(exercise => ({
+      exercise_id: exercise.exercise_id,
+      name: exercise.name,
+      reps: exercise.default_reps ?? '',
+      duration_minutes: exercise.default_duration_minutes ?? '',
+      notes: ''
+    }));
+
+    const machines = (selectedGroup.machines || []).map(machine => ({
+      machine_id: machine.machine_id,
+      name: machine.name,
+      duration_minutes: machine.default_duration_minutes ?? '',
+      notes: ''
+    }));
+
+    populateExercises(exercises);
+    populateMachines(machines);
+  }
+
+  function validateUniqueTreatmentSelections() {
+    const duplicateExercise = findDuplicateSelection('.exercise-select', '.other-name', 'exercise', exerciseMaster);
+    if (duplicateExercise) {
+      showToast('Same exercise is not allowed twice in one treatment session.');
+      return false;
+    }
+
+    const duplicateMachine = findDuplicateSelection('.machine-select', '.other-machine-name', 'machine', machineMaster);
+    if (duplicateMachine) {
+      showToast('Same machine is not allowed twice in one treatment session.');
+      return false;
+    }
+
+    return true;
+  }
+
+  function findDuplicateSelection(selectSelector, otherInputSelector, itemType, masterItems) {
+    const seen = new Set();
+    const selects = document.querySelectorAll(selectSelector);
+    for (const select of selects) {
+      let key = '';
+      if (select.value === 'other') {
+        const row = select.closest(itemType === 'exercise' ? '.exercise-row' : '.machine-row');
+        const customInput = row ? row.querySelector(otherInputSelector) : null;
+        const customName = customInput ? customInput.value.trim().replace(/\s+/g, ' ').toLowerCase() : '';
+        if (!customName) {
+          continue;
+        }
+        const existingItem = masterItems.find(item => String(item.name || '').trim().replace(/\s+/g, ' ').toLowerCase() === customName);
+        key = existingItem ? 'id:' + existingItem.id : 'custom:' + customName;
+      } else if (select.value) {
+        key = 'id:' + select.value;
+      }
+
+      if (key && seen.has(key)) {
+        return true;
+      }
+      if (key) {
+        seen.add(key);
+      }
+    }
+
+    return false;
   }
 
   function populateExercises(exercises) {
@@ -1308,16 +1418,35 @@ include '../../includes/header.php';
       if ($(sel).data('select2')) {
         $(sel).select2('destroy');
       }
+      const selectedValues = Array.from(selects)
+        .filter(other => other !== sel)
+        .map(other => other.value)
+        .filter(value => value && value !== 'other');
       sel.innerHTML = '<option value="">-- Select Machine --</option>' +
-        machineMaster.map(machine => `<option value="${machine.id}" data-default-duration="${machine.default_duration_minutes ?? ''}">${machine.name}</option>`).join('') +
+        machineMaster.map(machine => {
+          const disabled = selectedValues.includes(String(machine.id)) && String(machine.id) !== currentValue;
+          return `<option value="${machine.id}" data-default-duration="${machine.default_duration_minutes ?? ''}" ${disabled ? 'disabled' : ''}>${machine.name}</option>`;
+        }).join('') +
         '<option value="other">Others</option>';
       sel.value = currentValue;
       $(sel).select2({width: '100%'});
       $(sel).on('change.machine', function(){
         handleMachineChange(this);
+        updateMachineOptions();
       });
       handleMachineChange(sel);
     });
+  }
+
+  function showToast(message) {
+    const toastElement = document.getElementById('errorToast');
+    const toastMessage = document.getElementById('toastMsg');
+    if (toastElement && toastMessage && window.bootstrap) {
+      toastMessage.textContent = message;
+      bootstrap.Toast.getOrCreateInstance(toastElement).show();
+    } else {
+      alert(message);
+    }
   }
 
   function handleMachineChange(sel) {

--- a/views/shared/manage_exercise_groups_content.php
+++ b/views/shared/manage_exercise_groups_content.php
@@ -1,0 +1,248 @@
+<?php
+$editingGroupId = isset($_GET['edit']) ? (int) $_GET['edit'] : 0;
+$editingGroup = $editingGroupId > 0 ? $groupController->getGroupDetails($editingGroupId) : null;
+$editingExerciseIds = [];
+$editingMachineIds = [];
+if ($editingGroup) {
+    $editingExerciseIds = array_map('intval', array_column($editingGroup['exercises'], 'exercise_id'));
+    $editingMachineIds = array_map('intval', array_column($editingGroup['machines'], 'machine_id'));
+}
+?>
+<div class="app-card">
+    <?php if (!empty($msg)): ?>
+        <div class="alert alert-info mb-4" role="alert"><?= htmlspecialchars($msg) ?></div>
+    <?php endif; ?>
+
+    <form method="GET" class="row g-3 align-items-end mb-0">
+        <div class="col-12 col-md-6 col-lg-4">
+            <label for="search" class="form-label">Search exercise groups</label>
+            <input type="text" id="search" name="search" class="form-control" placeholder="Group title" value="<?= htmlspecialchars($search) ?>">
+        </div>
+        <div class="col-12 col-md-3 col-lg-2">
+            <button class="btn btn-primary w-100">Search</button>
+        </div>
+    </form>
+</div>
+
+<div class="app-card">
+    <h5 class="mb-3"><?= $editingGroup ? 'Edit Exercise Group' : 'Add Exercise Group' ?></h5>
+    <form method="POST" class="d-flex flex-column gap-3">
+        <input type="hidden" name="action" value="<?= $editingGroup ? 'edit_group' : 'add_group' ?>">
+        <?php if ($editingGroup): ?>
+            <input type="hidden" name="id" value="<?= (int) $editingGroup['id'] ?>">
+        <?php endif; ?>
+
+        <div class="row g-3">
+            <div class="col-12 col-md-8">
+                <label for="title" class="form-label">Group title</label>
+                <input type="text" id="title" name="title" class="form-control" placeholder="e.g. Neck Pain" value="<?= htmlspecialchars($editingGroup['title'] ?? '') ?>" required>
+            </div>
+            <div class="col-12 col-md-4">
+                <label for="is_active" class="form-label">Status</label>
+                <select id="is_active" name="is_active" class="form-select" required>
+                    <?php $activeValue = (string) ($editingGroup['is_active'] ?? 1); ?>
+                    <option value="1" <?= $activeValue === '1' ? 'selected' : '' ?>>Active</option>
+                    <option value="0" <?= $activeValue === '0' ? 'selected' : '' ?>>Inactive</option>
+                </select>
+            </div>
+        </div>
+
+        <div>
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                <h6 class="mb-0">Exercises</h6>
+                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addGroupExercise()">+ Add Exercise</button>
+            </div>
+            <div id="groupExerciseContainer" class="mt-3 d-flex flex-column gap-2"></div>
+        </div>
+
+        <div>
+            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                <h6 class="mb-0">Machines</h6>
+                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addGroupMachine()">+ Add Machine</button>
+            </div>
+            <div id="groupMachineContainer" class="mt-3 d-flex flex-column gap-2"></div>
+        </div>
+
+        <div class="d-flex gap-2">
+            <button class="btn btn-success"><?= $editingGroup ? 'Update Group' : 'Save Group' ?></button>
+            <?php if ($editingGroup): ?>
+                <a href="<?= htmlspecialchars($pageUrl) ?>" class="btn btn-outline-secondary">Cancel</a>
+            <?php endif; ?>
+        </div>
+    </form>
+</div>
+
+<div class="app-card">
+    <h5 class="mb-3">Exercise Groups</h5>
+    <div class="table-responsive">
+        <table class="table table-hover align-middle mb-0">
+            <thead>
+                <tr>
+                    <th scope="col">Title</th>
+                    <th scope="col">Exercises</th>
+                    <th scope="col">Machines</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Created By</th>
+                    <th scope="col" class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if (empty($groups)): ?>
+                    <tr><td colspan="6" class="text-center text-muted">No exercise groups found.</td></tr>
+                <?php endif; ?>
+                <?php foreach ($groups as $group): ?>
+                    <tr>
+                        <td><?= htmlspecialchars($group['title']) ?></td>
+                        <td><?= (int) $group['exercise_count'] ?></td>
+                        <td><?= (int) $group['machine_count'] ?></td>
+                        <td>
+                            <span class="badge <?= $group['is_active'] ? 'text-bg-success' : 'text-bg-secondary' ?>">
+                                <?= $group['is_active'] ? 'Active' : 'Inactive' ?>
+                            </span>
+                        </td>
+                        <td><?= htmlspecialchars($group['created_by_name'] ?? '—') ?></td>
+                        <td class="text-end">
+                            <div class="d-flex flex-wrap justify-content-end gap-2">
+                                <a class="btn btn-sm btn-info" href="<?= htmlspecialchars($pageUrl) ?>?edit=<?= (int) $group['id'] ?>&search=<?= urlencode($search) ?>">Edit</a>
+                                <form method="POST" class="d-inline">
+                                    <input type="hidden" name="action" value="toggle_group">
+                                    <input type="hidden" name="id" value="<?= (int) $group['id'] ?>">
+                                    <button class="btn btn-sm <?= $group['is_active'] ? 'btn-warning' : 'btn-success' ?>">
+                                        <?= $group['is_active'] ? 'Deactivate' : 'Activate' ?>
+                                    </button>
+                                </form>
+                                <form method="POST" class="d-inline" onsubmit="return confirm('Delete this exercise group?');">
+                                    <input type="hidden" name="action" value="delete_group">
+                                    <input type="hidden" name="id" value="<?= (int) $group['id'] ?>">
+                                    <button class="btn btn-sm btn-danger">Delete</button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+
+    <?php if ($totalPages > 1): ?>
+        <nav class="mt-3" aria-label="Exercise group pagination">
+            <ul class="pagination mb-0">
+                <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+                    <li class="page-item <?= $i == $page ? 'active' : '' ?>">
+                        <a class="page-link" href="<?= htmlspecialchars($pageUrl) ?>?page=<?= $i ?>&search=<?= urlencode($search) ?>"><?= $i ?></a>
+                    </li>
+                <?php endfor; ?>
+            </ul>
+        </nav>
+    <?php endif; ?>
+</div>
+
+<script>
+const groupExerciseMaster = <?= json_encode($exerciseMaster, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
+const groupMachineMaster = <?= json_encode($machineMaster, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
+const initialGroupExerciseIds = <?= json_encode($editingExerciseIds) ?>;
+const initialGroupMachineIds = <?= json_encode($editingMachineIds) ?>;
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (initialGroupExerciseIds.length) {
+        initialGroupExerciseIds.forEach(id => addGroupExercise(String(id)));
+    } else {
+        addGroupExercise();
+    }
+
+    if (initialGroupMachineIds.length) {
+        initialGroupMachineIds.forEach(id => addGroupMachine(String(id)));
+    } else {
+        addGroupMachine();
+    }
+});
+
+function buildOptions(items, selectedValue, placeholder) {
+    return `<option value="">${placeholder}</option>` + items.map(item => {
+        const selected = String(item.id) === String(selectedValue) ? 'selected' : '';
+        return `<option value="${item.id}" ${selected}>${escapeHtml(item.name)}</option>`;
+    }).join('');
+}
+
+function addGroupExercise(selectedValue = '') {
+    const container = document.getElementById('groupExerciseContainer');
+    const row = document.createElement('div');
+    row.className = 'row g-2 align-items-center group-exercise-row';
+    row.innerHTML = `
+        <div class="col-10 col-md-11">
+            <select name="exercise_ids[]" class="form-select group-exercise-select">
+                ${buildOptions(groupExerciseMaster, selectedValue, '-- Select Exercise --')}
+            </select>
+        </div>
+        <div class="col-2 col-md-1">
+            <button type="button" class="btn btn-danger btn-sm w-100" onclick="removeGroupRow(this, updateGroupExerciseOptions)">Remove</button>
+        </div>
+    `;
+    container.appendChild(row);
+    $(row).find('.group-exercise-select').select2({width: '100%'}).on('change', updateGroupExerciseOptions);
+    updateGroupExerciseOptions();
+}
+
+function addGroupMachine(selectedValue = '') {
+    const container = document.getElementById('groupMachineContainer');
+    const row = document.createElement('div');
+    row.className = 'row g-2 align-items-center group-machine-row';
+    row.innerHTML = `
+        <div class="col-10 col-md-11">
+            <select name="machine_ids[]" class="form-select group-machine-select">
+                ${buildOptions(groupMachineMaster, selectedValue, '-- Select Machine --')}
+            </select>
+        </div>
+        <div class="col-2 col-md-1">
+            <button type="button" class="btn btn-danger btn-sm w-100" onclick="removeGroupRow(this, updateGroupMachineOptions)">Remove</button>
+        </div>
+    `;
+    container.appendChild(row);
+    $(row).find('.group-machine-select').select2({width: '100%'}).on('change', updateGroupMachineOptions);
+    updateGroupMachineOptions();
+}
+
+function removeGroupRow(button, callback) {
+    const row = button.closest('.row');
+    $(row).find('select').each(function () {
+        if ($(this).data('select2')) {
+            $(this).select2('destroy');
+        }
+    });
+    row.remove();
+    callback();
+}
+
+function updateGroupExerciseOptions() {
+    disableDuplicateOptions('.group-exercise-select');
+}
+
+function updateGroupMachineOptions() {
+    disableDuplicateOptions('.group-machine-select');
+}
+
+function disableDuplicateOptions(selector) {
+    const selects = Array.from(document.querySelectorAll(selector));
+    const selectedValues = selects.map(select => select.value).filter(Boolean);
+
+    selects.forEach(select => {
+        const currentValue = select.value;
+        Array.from(select.options).forEach(option => {
+            option.disabled = option.value !== '' && option.value !== currentValue && selectedValues.includes(option.value);
+        });
+        if ($(select).data('select2')) {
+            $(select).trigger('change.select2');
+        }
+    });
+}
+
+function escapeHtml(value) {
+    return String(value).replace(/[&<>'"]/g, char => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        "'": '&#039;',
+        '"': '&quot;'
+    }[char]));
+}
+</script>


### PR DESCRIPTION
### Motivation
- Reduce repetitive daily work by letting admins/doctors create named exercise groups (bundles of exercises and machines) that can be applied during patient treatment.
- Ensure data integrity by preventing the same Exercise or Machine from being added more than once in a single treatment session, including matching custom "Other" entries against master records.

### Description
- Add MySQL 8.0 compatible migration `config/exercise_groups.sql` that creates `exercise_groups`, `exercise_group_exercises`, and `exercise_group_machines` with appropriate indexes and InnoDB foreign keys.
- Implement `controllers/ExerciseGroupController.php` for CRUD and listing of groups and their ordered items, plus helper methods to return active groups with their items and master lists.
- Add management UIs `views/admin/manage_exercise_groups.php`, `views/doctor/manage_exercise_groups.php` and shared partial `views/shared/manage_exercise_groups_content.php` with add-more rows for exercises and machines and UI logic to disable duplicate selections when building a group.
- Integrate groups into the treatment flow by adding an "Apply Exercise Group" selector to `views/doctor/start_treatment.php`, client-side code to populate exercises/machines from a group, and UI updates to disable duplicates and auto-fill defaults.
- Add server-side validation and helpers to `controllers/TreatmentController.php` to block duplicate exercises/machines on save/update (`validateNoDuplicateTreatmentItems`, `assertNoDuplicateSelections`, `normalizeTreatmentItemName`, `findOrCreateExercise`), and enhance client JS to validate before submit and show toast messages.
- Add navigation links to Admin and Doctor sidebars for the new Exercise Groups pages.

### Testing
- Ran PHP syntax checks across controllers/views/layouts with `find controllers views layouts -name '*.php' -print | xargs -n1 php -l`, and all modified/added files passed without syntax errors.
- Ran `git diff --check` and repository lint checks against modified files to catch whitespace or diff issues, with no problems reported.
- Performed application-level static checks (PHP lints for modified views/controllers) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031be767a48322b0247389054f708f)