### PR TITLE
Refactor exercise groups page to use modal for Add/Edit (CRUD UX)

### DIFF
--- a/views/shared/manage_exercise_groups_content.php
+++ b/views/shared/manage_exercise_groups_content.php
@@ -7,73 +7,46 @@ if ($editingGroup) {
     $editingExerciseIds = array_map('intval', array_column($editingGroup['exercises'], 'exercise_id'));
     $editingMachineIds = array_map('intval', array_column($editingGroup['machines'], 'machine_id'));
 }
+$listParams = [];
+if ($page > 1) {
+    $listParams['page'] = $page;
+}
+if ($search !== '') {
+    $listParams['search'] = $search;
+}
+$listQuery = http_build_query($listParams);
+$listUrl = $pageUrl . ($listQuery !== '' ? '?' . $listQuery : '');
 ?>
 <div class="app-card">
     <?php if (!empty($msg)): ?>
         <div class="alert alert-info mb-4" role="alert"><?= htmlspecialchars($msg) ?></div>
     <?php endif; ?>
 
-    <form method="GET" class="row g-3 align-items-end mb-0">
-        <div class="col-12 col-md-6 col-lg-4">
-            <label for="search" class="form-label">Search exercise groups</label>
-            <input type="text" id="search" name="search" class="form-control" placeholder="Group title" value="<?= htmlspecialchars($search) ?>">
+    <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
+        <form method="GET" class="row g-3 align-items-end flex-grow-1 mb-0">
+            <div class="col-12 col-md-6 col-lg-4">
+                <label for="search" class="form-label">Search exercise groups</label>
+                <input type="text" id="search" name="search" class="form-control" placeholder="Group title" value="<?= htmlspecialchars($search) ?>">
+            </div>
+            <div class="col-12 col-md-3 col-lg-2">
+                <button class="btn btn-primary w-100">Search</button>
+            </div>
+        </form>
+        <div class="pt-md-4">
+            <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#exerciseGroupModal" onclick="openAddGroupModal()">
+                + Add Exercise Group
+            </button>
         </div>
-        <div class="col-12 col-md-3 col-lg-2">
-            <button class="btn btn-primary w-100">Search</button>
-        </div>
-    </form>
+    </div>
 </div>
 
 <div class="app-card">
-    <h5 class="mb-3"><?= $editingGroup ? 'Edit Exercise Group' : 'Add Exercise Group' ?></h5>
-    <form method="POST" class="d-flex flex-column gap-3">
-        <input type="hidden" name="action" value="<?= $editingGroup ? 'edit_group' : 'add_group' ?>">
-        <?php if ($editingGroup): ?>
-            <input type="hidden" name="id" value="<?= (int) $editingGroup['id'] ?>">
-        <?php endif; ?>
-
-        <div class="row g-3">
-            <div class="col-12 col-md-8">
-                <label for="title" class="form-label">Group title</label>
-                <input type="text" id="title" name="title" class="form-control" placeholder="e.g. Neck Pain" value="<?= htmlspecialchars($editingGroup['title'] ?? '') ?>" required>
-            </div>
-            <div class="col-12 col-md-4">
-                <label for="is_active" class="form-label">Status</label>
-                <select id="is_active" name="is_active" class="form-select" required>
-                    <?php $activeValue = (string) ($editingGroup['is_active'] ?? 1); ?>
-                    <option value="1" <?= $activeValue === '1' ? 'selected' : '' ?>>Active</option>
-                    <option value="0" <?= $activeValue === '0' ? 'selected' : '' ?>>Inactive</option>
-                </select>
-            </div>
-        </div>
-
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
         <div>
-            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-                <h6 class="mb-0">Exercises</h6>
-                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addGroupExercise()">+ Add Exercise</button>
-            </div>
-            <div id="groupExerciseContainer" class="mt-3 d-flex flex-column gap-2"></div>
+            <h5 class="mb-1">Exercise Groups</h5>
+            <p class="text-muted mb-0">Manage exercise groups with create, update, activate/deactivate, and delete actions.</p>
         </div>
-
-        <div>
-            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-                <h6 class="mb-0">Machines</h6>
-                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addGroupMachine()">+ Add Machine</button>
-            </div>
-            <div id="groupMachineContainer" class="mt-3 d-flex flex-column gap-2"></div>
-        </div>
-
-        <div class="d-flex gap-2">
-            <button class="btn btn-success"><?= $editingGroup ? 'Update Group' : 'Save Group' ?></button>
-            <?php if ($editingGroup): ?>
-                <a href="<?= htmlspecialchars($pageUrl) ?>" class="btn btn-outline-secondary">Cancel</a>
-            <?php endif; ?>
-        </div>
-    </form>
-</div>
-
-<div class="app-card">
-    <h5 class="mb-3">Exercise Groups</h5>
+    </div>
     <div class="table-responsive">
         <table class="table table-hover align-middle mb-0">
             <thead>
@@ -83,7 +56,7 @@ if ($editingGroup) {
                     <th scope="col">Machines</th>
                     <th scope="col">Status</th>
                     <th scope="col">Created By</th>
-                    <th scope="col" class="text-end">Actions</th>
+                    <th scope="col" class="text-end">CRUD Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -103,7 +76,7 @@ if ($editingGroup) {
                         <td><?= htmlspecialchars($group['created_by_name'] ?? '—') ?></td>
                         <td class="text-end">
                             <div class="d-flex flex-wrap justify-content-end gap-2">
-                                <a class="btn btn-sm btn-info" href="<?= htmlspecialchars($pageUrl) ?>?edit=<?= (int) $group['id'] ?>&search=<?= urlencode($search) ?>">Edit</a>
+                                <a class="btn btn-sm btn-info" href="<?= htmlspecialchars($pageUrl) ?>?edit=<?= (int) $group['id'] ?>&page=<?= (int) $page ?>&search=<?= urlencode($search) ?>">Edit</a>
                                 <form method="POST" class="d-inline">
                                     <input type="hidden" name="action" value="toggle_group">
                                     <input type="hidden" name="id" value="<?= (int) $group['id'] ?>">
@@ -137,25 +110,137 @@ if ($editingGroup) {
     <?php endif; ?>
 </div>
 
+<div class="modal fade" id="exerciseGroupModal" tabindex="-1" aria-labelledby="exerciseGroupModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <form method="POST" action="<?= htmlspecialchars($listUrl) ?>" class="d-flex flex-column">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="exerciseGroupModalLabel"><?= $editingGroup ? 'Edit Exercise Group' : 'Add Exercise Group' ?></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body d-flex flex-column gap-3">
+                    <input type="hidden" id="groupFormAction" name="action" value="<?= $editingGroup ? 'edit_group' : 'add_group' ?>">
+                    <input type="hidden" id="groupId" name="id" value="<?= $editingGroup ? (int) $editingGroup['id'] : '' ?>">
+
+                    <div class="row g-3">
+                        <div class="col-12 col-md-8">
+                            <label for="groupTitle" class="form-label">Group title</label>
+                            <input type="text" id="groupTitle" name="title" class="form-control" placeholder="e.g. Neck Pain" value="<?= htmlspecialchars($editingGroup['title'] ?? '') ?>" required>
+                        </div>
+                        <div class="col-12 col-md-4">
+                            <label for="groupIsActive" class="form-label">Status</label>
+                            <select id="groupIsActive" name="is_active" class="form-select" required>
+                                <?php $activeValue = (string) ($editingGroup['is_active'] ?? 1); ?>
+                                <option value="1" <?= $activeValue === '1' ? 'selected' : '' ?>>Active</option>
+                                <option value="0" <?= $activeValue === '0' ? 'selected' : '' ?>>Inactive</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                            <h6 class="mb-0">Exercises</h6>
+                            <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addGroupExercise()">+ Add Exercise</button>
+                        </div>
+                        <div id="groupExerciseContainer" class="mt-3 d-flex flex-column gap-2"></div>
+                    </div>
+
+                    <div>
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                            <h6 class="mb-0">Machines</h6>
+                            <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addGroupMachine()">+ Add Machine</button>
+                        </div>
+                        <div id="groupMachineContainer" class="mt-3 d-flex flex-column gap-2"></div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button class="btn btn-success" id="groupSubmitButton"><?= $editingGroup ? 'Update Group' : 'Save Group' ?></button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 <script>
 const groupExerciseMaster = <?= json_encode($exerciseMaster, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
 const groupMachineMaster = <?= json_encode($machineMaster, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
 const initialGroupExerciseIds = <?= json_encode($editingExerciseIds) ?>;
 const initialGroupMachineIds = <?= json_encode($editingMachineIds) ?>;
+const editingGroup = <?= json_encode($editingGroup ? [
+    'id' => (int) $editingGroup['id'],
+    'title' => $editingGroup['title'],
+    'is_active' => (int) $editingGroup['is_active'],
+] : null, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
+
+let exerciseGroupModal;
 
 document.addEventListener('DOMContentLoaded', () => {
-    if (initialGroupExerciseIds.length) {
-        initialGroupExerciseIds.forEach(id => addGroupExercise(String(id)));
+    exerciseGroupModal = new bootstrap.Modal(document.getElementById('exerciseGroupModal'));
+
+    if (editingGroup) {
+        openEditGroupModal(editingGroup, initialGroupExerciseIds, initialGroupMachineIds);
+    } else {
+        resetGroupRows();
+    }
+
+    document.getElementById('exerciseGroupModal').addEventListener('hidden.bs.modal', () => {
+        if (editingGroup) {
+            window.location.href = <?= json_encode($listUrl, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
+        }
+    });
+});
+
+function openAddGroupModal() {
+    setGroupFormMode('add');
+    document.getElementById('groupTitle').value = '';
+    document.getElementById('groupIsActive').value = '1';
+    document.getElementById('groupId').value = '';
+    resetGroupRows();
+}
+
+function openEditGroupModal(group, exerciseIds, machineIds) {
+    setGroupFormMode('edit');
+    document.getElementById('groupTitle').value = group.title;
+    document.getElementById('groupIsActive').value = String(group.is_active);
+    document.getElementById('groupId').value = group.id;
+    resetGroupRows(exerciseIds, machineIds);
+    exerciseGroupModal.show();
+}
+
+function setGroupFormMode(mode) {
+    const isEdit = mode === 'edit';
+    document.getElementById('exerciseGroupModalLabel').textContent = isEdit ? 'Edit Exercise Group' : 'Add Exercise Group';
+    document.getElementById('groupFormAction').value = isEdit ? 'edit_group' : 'add_group';
+    document.getElementById('groupSubmitButton').textContent = isEdit ? 'Update Group' : 'Save Group';
+}
+
+function resetGroupRows(exerciseIds = [], machineIds = []) {
+    clearGroupRows('groupExerciseContainer');
+    clearGroupRows('groupMachineContainer');
+
+    if (exerciseIds.length) {
+        exerciseIds.forEach(id => addGroupExercise(String(id)));
     } else {
         addGroupExercise();
     }
 
-    if (initialGroupMachineIds.length) {
-        initialGroupMachineIds.forEach(id => addGroupMachine(String(id)));
+    if (machineIds.length) {
+        machineIds.forEach(id => addGroupMachine(String(id)));
     } else {
         addGroupMachine();
     }
-});
+}
+
+function clearGroupRows(containerId) {
+    const container = document.getElementById(containerId);
+    $(container).find('select').each(function () {
+        if ($(this).data('select2')) {
+            $(this).select2('destroy');
+        }
+    });
+    container.innerHTML = '';
+}
 
 function buildOptions(items, selectedValue, placeholder) {
     return `<option value="">${placeholder}</option>` + items.map(item => {
@@ -179,7 +264,7 @@ function addGroupExercise(selectedValue = '') {
         </div>
     `;
     container.appendChild(row);
-    $(row).find('.group-exercise-select').select2({width: '100%'}).on('change', updateGroupExerciseOptions);
+    $(row).find('.group-exercise-select').select2({dropdownParent: $('#exerciseGroupModal'), width: '100%'}).on('change', updateGroupExerciseOptions);
     updateGroupExerciseOptions();
 }
 
@@ -198,7 +283,7 @@ function addGroupMachine(selectedValue = '') {
         </div>
     `;
     container.appendChild(row);
-    $(row).find('.group-machine-select').select2({width: '100%'}).on('change', updateGroupMachineOptions);
+    $(row).find('.group-machine-select').select2({dropdownParent: $('#exerciseGroupModal'), width: '100%'}).on('change', updateGroupMachineOptions);
     updateGroupMachineOptions();
 }
 


### PR DESCRIPTION
### Motivation
- The existing page mixed Add and Edit in the same visible form, which was confusing for users; the intent is to convert the UI to a clearer CRUD workflow where Add and Edit are modal-driven.
- Preserve existing behavior and validation while improving discoverability and keeping pagination/search context when returning from an edit.

### Description
- Replaced the always-visible add/edit form with an `+ Add Exercise Group` button and a Bootstrap modal implemented in `views/shared/manage_exercise_groups_content.php` that contains the same fields for title, status, exercises, and machines.
- Reused the modal for edit mode by adding `openAddGroupModal`, `openEditGroupModal`, `setGroupFormMode`, `resetGroupRows`, and `clearGroupRows` helpers and automatically opening the modal when `?edit=` is present.
- Preserved list context by building a `listUrl` that includes `page`/`search` parameters and setting the modal form `action` to `<?= htmlspecialchars($listUrl) ?>` so submissions and returns keep the list state.
- Improved Select2 usage inside the modal by setting `dropdownParent: $('#exerciseGroupModal')` and kept duplicate-option prevention logic for dynamically added exercise/machine rows.
- Updated Edit links to include the `page` parameter so editing preserves pagination (`?edit=...&page=...&search=...`).

### Testing
- Ran syntax checks successfully with `php -l views/shared/manage_exercise_groups_content.php`, `php -l views/admin/manage_exercise_groups.php`, and `php -l views/doctor/manage_exercise_groups.php` and they returned no syntax errors. 
- Ran `git diff --check` and static diff summary to confirm there are no trailing whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032600613c8322aa72d60f1a91b216)