### PR TITLE
Add patient attendance calendar to patient dashboard

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -222,3 +222,112 @@ body {
 .toast-container {
   z-index: 1090;
 }
+
+.patient-calendar-card {
+  overflow: hidden;
+}
+
+.patient-calendar-legend {
+  align-items: center;
+  color: #4b5563;
+  display: flex;
+  font-size: 0.9rem;
+  gap: 0.5rem;
+}
+
+.patient-calendar-legend-dot {
+  background-color: #198754;
+  border-radius: 999px;
+  box-shadow: 0 0 0 0.25rem rgba(25, 135, 84, 0.12);
+  flex: 0 0 0.75rem;
+  height: 0.75rem;
+  width: 0.75rem;
+}
+
+.patient-calendar {
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.patient-calendar-weekday {
+  color: #64748b;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.patient-calendar-day {
+  align-items: flex-start;
+  aspect-ratio: 1 / 1;
+  background-color: #f8fafc;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.8rem;
+  color: #1f2937;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 4.75rem;
+  padding: 0.6rem;
+}
+
+.patient-calendar-day.is-muted {
+  color: #94a3b8;
+  opacity: 0.65;
+}
+
+.patient-calendar-day.is-present {
+  background: linear-gradient(135deg, #198754, #22c55e);
+  border-color: rgba(25, 135, 84, 0.45);
+  box-shadow: 0 0.75rem 1.5rem rgba(25, 135, 84, 0.16);
+  color: #ffffff;
+  opacity: 1;
+}
+
+.patient-calendar-date {
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.patient-calendar-status {
+  align-self: stretch;
+  background-color: rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.28rem 0.35rem;
+  text-align: center;
+}
+
+@media (max-width: 575.98px) {
+  .patient-calendar-card {
+    padding: 1rem;
+  }
+
+  .patient-calendar {
+    gap: 0.28rem;
+  }
+
+  .patient-calendar-weekday {
+    font-size: 0.62rem;
+  }
+
+  .patient-calendar-day {
+    border-radius: 0.55rem;
+    min-height: 3.45rem;
+    padding: 0.4rem 0.32rem;
+  }
+
+  .patient-calendar-date {
+    font-size: 0.88rem;
+  }
+
+  .patient-calendar-status {
+    font-size: 0.58rem;
+    padding: 0.22rem 0.16rem;
+  }
+}

--- a/views/patient/dashboard.php
+++ b/views/patient/dashboard.php
@@ -23,6 +23,45 @@ $lastSessionStmt = $pdo->prepare(
 $lastSessionStmt->execute([$patientId]);
 $lastSessionDate = $lastSessionStmt->fetchColumn();
 
+$requestedMonth = $_GET['month'] ?? date('Y-m');
+$monthStart = preg_match('/^\d{4}-\d{2}$/', $requestedMonth)
+    ? DateTimeImmutable::createFromFormat('!Y-m-d', $requestedMonth . '-01')
+    : false;
+$monthStartErrors = DateTimeImmutable::getLastErrors();
+if (!$monthStart || ($monthStartErrors && ($monthStartErrors['warning_count'] || $monthStartErrors['error_count']))) {
+    $monthStart = new DateTimeImmutable('first day of this month');
+}
+
+$monthEnd = $monthStart->modify('last day of this month');
+$nextMonthStart = $monthStart->modify('first day of next month');
+$calendarStart = $monthStart->modify('-' . (int) $monthStart->format('w') . ' days');
+$calendarEnd = $monthEnd->modify('+' . (6 - (int) $monthEnd->format('w')) . ' days');
+$previousMonth = $monthStart->modify('-1 month')->format('Y-m');
+$nextMonth = $monthStart->modify('+1 month')->format('Y-m');
+$currentMonth = (new DateTimeImmutable('first day of this month'))->format('Y-m');
+$selectedMonth = $monthStart->format('Y-m');
+
+$presentDatesStmt = $pdo->prepare(
+    "SELECT DATE(session_date) AS visit_date, COUNT(*) AS visit_count
+     FROM treatment_sessions
+     WHERE patient_id = ? AND session_date >= ? AND session_date < ?
+     GROUP BY DATE(session_date)"
+);
+$presentDatesStmt->execute([
+    $patientId,
+    $monthStart->format('Y-m-d'),
+    $nextMonthStart->format('Y-m-d'),
+]);
+$presentDates = [];
+foreach ($presentDatesStmt->fetchAll(PDO::FETCH_ASSOC) as $presentDateRow) {
+    $presentDates[$presentDateRow['visit_date']] = (int) $presentDateRow['visit_count'];
+}
+
+$calendarDays = [];
+for ($day = $calendarStart; $day <= $calendarEnd; $day = $day->modify('+1 day')) {
+    $calendarDays[] = $day;
+}
+
 include '../../includes/header.php';
 ?>
 <div class="workspace-layout">
@@ -38,6 +77,54 @@ include '../../includes/header.php';
         <?php if (!$patient): ?>
             <div class="alert alert-danger">Unable to load your profile. Please contact the clinic.</div>
         <?php else: ?>
+            <div class="app-card patient-calendar-card">
+                <div class="d-flex flex-column flex-sm-row gap-3 justify-content-between align-items-sm-center mb-3">
+                    <div>
+                        <div class="text-uppercase small text-muted fw-semibold">Attendance Calendar</div>
+                        <h5 class="mb-0"><?= htmlspecialchars($monthStart->format('F Y')) ?></h5>
+                    </div>
+                    <div class="d-flex flex-wrap gap-2" aria-label="Calendar month navigation">
+                        <a class="btn btn-outline-primary btn-sm" href="?month=<?= htmlspecialchars($previousMonth) ?>">&larr; Previous</a>
+                        <?php if ($selectedMonth !== $currentMonth): ?>
+                            <a class="btn btn-outline-secondary btn-sm" href="?month=<?= htmlspecialchars($currentMonth) ?>">Current Month</a>
+                        <?php endif; ?>
+                        <a class="btn btn-outline-primary btn-sm" href="?month=<?= htmlspecialchars($nextMonth) ?>">Next &rarr;</a>
+                    </div>
+                </div>
+
+                <div class="patient-calendar-legend mb-3">
+                    <span class="patient-calendar-legend-dot"></span>
+                    <span>Green dates show days you were marked present for treatment.</span>
+                </div>
+
+                <div class="patient-calendar" role="grid" aria-label="Attendance calendar for <?= htmlspecialchars($monthStart->format('F Y')) ?>">
+                    <?php foreach (['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as $weekday): ?>
+                        <div class="patient-calendar-weekday" role="columnheader"><?= htmlspecialchars($weekday) ?></div>
+                    <?php endforeach; ?>
+
+                    <?php foreach ($calendarDays as $calendarDay): ?>
+                        <?php
+                            $calendarDate = $calendarDay->format('Y-m-d');
+                            $isCurrentMonthDay = $calendarDay->format('Y-m') === $selectedMonth;
+                            $isPresent = isset($presentDates[$calendarDate]);
+                            $dayClasses = ['patient-calendar-day'];
+                            if (!$isCurrentMonthDay) {
+                                $dayClasses[] = 'is-muted';
+                            }
+                            if ($isPresent) {
+                                $dayClasses[] = 'is-present';
+                            }
+                        ?>
+                        <div class="<?= htmlspecialchars(implode(' ', $dayClasses)) ?>" role="gridcell" aria-label="<?= htmlspecialchars($calendarDay->format('F j, Y') . ($isPresent ? ' - Present' : '')) ?>">
+                            <span class="patient-calendar-date"><?= htmlspecialchars($calendarDay->format('j')) ?></span>
+                            <?php if ($isPresent): ?>
+                                <span class="patient-calendar-status">Present</span>
+                            <?php endif; ?>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+
             <div class="row g-3 g-lg-4 mb-4">
                 <div class="col-12 col-md-4">
                     <div class="stat-card bg-primary text-white h-100">


### PR DESCRIPTION
### Motivation
- Provide patients with a month-aware attendance/calendar view on their dashboard so they can quickly see days they were present, optimized for mobile while keeping the existing dashboard content below.

### Description
- Added month parsing/validation and date-range generation (calendar start/end and previous/current/next month values) to `views/patient/dashboard.php` and compute a list of day objects for rendering.
- Query `treatment_sessions` for the selected patient and month (using `session_date >= ? AND session_date < ?`) and map visit dates to mark present days in the calendar.
- Render a responsive 7-column calendar grid above the existing dashboard stats with navigation links (`?month=YYYY-MM`) and accessibility attributes (`role`, `aria-label`) in `views/patient/dashboard.php`.
- Added responsive calendar styles and present-day highlighting to `assets/css/style.css` (mobile-first sizing, muted out-of-month days, green present styling).

### Testing
- Ran `php -l views/patient/dashboard.php` with no syntax errors (passed). 
- Ran `git diff --check` to validate whitespace/overlap issues (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03342c82348322a311046a8e5ad5de)