### PR TITLE
Allow admins to start treatment episodes

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -14,7 +14,9 @@ function requireLogin(?string $redirect = null) {
 function requireRole($role, ?string $redirect = null) {
     $redirectTo = $redirect ?? '../login.php';
     requireLogin($redirectTo);
-    if ($_SESSION['role'] !== $role) {
+
+    $allowedRoles = is_array($role) ? $role : [$role];
+    if (!in_array($_SESSION['role'] ?? '', $allowedRoles, true)) {
         header("Location: $redirectTo");
         exit;
     }

--- a/layouts/admin_sidebar.php
+++ b/layouts/admin_sidebar.php
@@ -19,7 +19,12 @@ $adminNavItems = [
     [
         'label' => 'Manage Patients',
         'href' => BASE_URL . '/views/admin/manage_patients.php',
-        'matches' => ['manage_patients.php', 'patient_form.php'],
+        'matches' => [
+            'manage_patients.php',
+            'patient_form.php',
+            'select_or_create_episode.php',
+            'start_treatment.php',
+        ],
     ],
     [
         'label' => 'Exercises',

--- a/views/admin/manage_patients.php
+++ b/views/admin/manage_patients.php
@@ -80,6 +80,7 @@ include '../../includes/header.php';
                         <td class="text-end">
                             <div class="d-flex flex-wrap justify-content-end gap-2">
                                 <a href="patient_form.php?id=<?= (int) $p['id'] ?>" class="btn btn-sm btn-info">Edit</a>
+                                <a href="../doctor/select_or_create_episode.php?patient_id=<?= (int) $p['id'] ?>" class="btn btn-sm btn-success">Start Treatment</a>
                                 <a href="../shared/manage_payments.php?patient_id=<?= (int) $p['id'] ?>" class="btn btn-sm btn-secondary">Payments</a>
                                 <a href="patient_password.php?patient_id=<?= (int) $p['id'] ?>" class="btn btn-sm btn-primary">Password</a>
                                 <a href="../shared/manage_patients_files.php?patient_id=<?= (int) $p['id'] ?>" class="btn btn-sm btn-warning">View Files</a>

--- a/views/doctor/select_or_create_episode.php
+++ b/views/doctor/select_or_create_episode.php
@@ -2,10 +2,18 @@
 require_once '../../includes/db.php';
 require_once '../../includes/auth.php';
 requireLogin();
-requireRole('Doctor');
+requireRole(['Doctor', 'Admin']);
 
 require_once '../../controllers/TreatmentController.php';
 $treatmentController = new TreatmentController($pdo);
+
+$isAdmin = ($_SESSION['role'] ?? '') === 'Admin';
+$patientsUrl = $isAdmin ? '../admin/manage_patients.php' : 'manage_patients.php';
+$layoutClass = $isAdmin ? 'admin-layout' : 'workspace-layout';
+$contentClass = $isAdmin ? 'admin-content' : 'workspace-content';
+$headerClass = $isAdmin ? 'admin-page-header' : 'workspace-page-header';
+$titleClass = $isAdmin ? 'admin-page-title' : 'workspace-page-title';
+$subtitleClass = $isAdmin ? 'admin-page-subtitle' : 'workspace-page-subtitle';
 
 // Get patient_id from query string
 $patient_id = isset($_GET['patient_id']) ? (int) $_GET['patient_id'] : 0;
@@ -50,16 +58,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 include '../../includes/header.php';
 
 ?>
-<div class="workspace-layout">
-  <?php include '../../layouts/doctor_sidebar.php'; ?>
-  <div class="workspace-content">
-    <div class="workspace-page-header">
+<div class="<?= $layoutClass ?>">
+  <?php include $isAdmin ? '../../layouts/admin_sidebar.php' : '../../layouts/doctor_sidebar.php'; ?>
+  <div class="<?= $contentClass ?>">
+    <div class="<?= $headerClass ?>">
       <div>
-        <h1 class="workspace-page-title">Treatment Episodes</h1>
-        <p class="workspace-page-subtitle">Manage care plans for <?= htmlspecialchars($patient['first_name'] . ' ' . $patient['last_name']) ?>.</p>
+        <h1 class="<?= $titleClass ?>">Treatment Episodes</h1>
+        <p class="<?= $subtitleClass ?>">Manage care plans for <?= htmlspecialchars($patient['first_name'] . ' ' . $patient['last_name']) ?>.</p>
       </div>
       <div class="d-flex gap-2">
-        <a href="manage_patients.php" class="btn btn-outline-secondary">Back to Patients</a>
+        <a href="<?= $patientsUrl ?>" class="btn btn-outline-secondary">Back to Patients</a>
       </div>
     </div>
 

--- a/views/doctor/start_treatment.php
+++ b/views/doctor/start_treatment.php
@@ -2,7 +2,7 @@
 require_once '../../includes/db.php';
 require_once '../../includes/auth.php';
 requireLogin();
-requireRole('Doctor');
+requireRole(['Doctor', 'Admin']);
 
 require_once '../../controllers/TreatmentController.php';
 require_once '../../controllers/PatientController.php';
@@ -13,6 +13,13 @@ $treatmentController = new TreatmentController($pdo);
 $patientController = new PatientController($pdo);
 $paymentController = new PaymentController($pdo);
 $exerciseGroupController = new ExerciseGroupController($pdo);
+
+$isAdmin = ($_SESSION['role'] ?? '') === 'Admin';
+$layoutClass = $isAdmin ? 'admin-layout' : 'workspace-layout';
+$contentClass = $isAdmin ? 'admin-content' : 'workspace-content';
+$headerClass = $isAdmin ? 'admin-page-header' : 'workspace-page-header';
+$titleClass = $isAdmin ? 'admin-page-title' : 'workspace-page-title';
+$subtitleClass = $isAdmin ? 'admin-page-subtitle' : 'workspace-page-subtitle';
 
 $patient_id = isset($_GET['patient_id']) ? (int) $_GET['patient_id'] : 0;
 $episode_id = isset($_GET['episode_id']) ? (int) $_GET['episode_id'] : 0;
@@ -504,15 +511,15 @@ include '../../includes/header.php';
     padding: 0.85rem;
   }
 </style>
-<div class="workspace-layout">
-  <?php include '../../layouts/doctor_sidebar.php'; ?>
-  <div class="workspace-content">
-    <div class="workspace-page-header">
+<div class="<?= $layoutClass ?>">
+  <?php include $isAdmin ? '../../layouts/admin_sidebar.php' : '../../layouts/doctor_sidebar.php'; ?>
+  <div class="<?= $contentClass ?>">
+    <div class="<?= $headerClass ?>">
       <div>
-        <h1 class="workspace-page-title">
+        <h1 class="<?= $titleClass ?>">
           <?= $isEditingSession ? 'Update Treatment Session' : 'Log Treatment Session' ?>
         </h1>
-        <p class="workspace-page-subtitle">Patient: <?= htmlspecialchars($patient_name) ?></p>
+        <p class="<?= $subtitleClass ?>">Patient: <?= htmlspecialchars($patient_name) ?></p>
       </div>
       <div class="d-flex gap-2">
         <?php if ($isEditingSession): ?>


### PR DESCRIPTION
### Motivation
- Enable Admin users to initiate treatment episodes and log sessions using the same flows Doctors use so that admins can start care for patients without switching to a doctor account. 
- Ensure UI and navigation render appropriately for Admins when they enter the episode/treatment pages.

### Description
- Make `requireRole` accept either a single role or an array of roles by adding array handling and membership checking in `includes/auth.php` so pages can allow multiple roles. 
- Add a “Start Treatment” action to the admin patient list in `views/admin/manage_patients.php` linking to the episode selection/creation flow. 
- Allow Admins to access the episode selection (`views/doctor/select_or_create_episode.php`) and treatment session (`views/doctor/start_treatment.php`) pages by calling `requireRole(['Doctor','Admin'])` and detect `Admin` to render admin layout, sidebar, and back navigation. 
- Mark the patient management navigation item active for these pages by adding `select_or_create_episode.php` and `start_treatment.php` to the `matches` list in `layouts/admin_sidebar.php`.

### Testing
- Ran `php -l includes/auth.php` which reported no syntax errors. (passed)
- Ran `php -l layouts/admin_sidebar.php` which reported no syntax errors. (passed)
- Ran `php -l views/admin/manage_patients.php` which reported no syntax errors. (passed)
- Ran `php -l views/doctor/select_or_create_episode.php` which reported no syntax errors. (passed)
- Ran `php -l views/doctor/start_treatment.php` which reported no syntax errors. (passed)
- Ran `git diff --check` to validate whitespace/patch issues which passed. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae4ee92988322a2013290199ccfcb)